### PR TITLE
update circleci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.6.5
+      - image: cimg/python:3.6.9
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -27,6 +27,7 @@ jobs:
       - run:
           name: Install Linux system dependencies
           command: |
+             sudo apt-get update
              sudo apt-get install freetds-dev
       # Download and cache dependencies
       - restore_cache:


### PR DESCRIPTION
Please include a summary of the change and which issue is addressed.
The current CircleCI image is outdated and having issues to install `freetds-dev`. Update CircleCI image to a new one.

## PR Self Evaluation

- [x] I have reviewed my code to check that it contains no sensitive information.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests or modified existing tests that prove my fix is effective or that my feature works
- [x] Existing unit tests pass locally with my changes

