### PR TITLE
Clean up logs

### DIFF
--- a/processing/base_creator.py
+++ b/processing/base_creator.py
@@ -254,7 +254,7 @@ class BASECreator():
         base_path = attr.get('base_path')
         res = attr.get('res')
         file_attr = []
-        process_id = self.preBASE_files.get(str(f))
+        process_id = self.preBASE_files.get(str(f_path))
         try:
             _log.info(f'Creating BASE files for candidate: {f_path.name}')
             last_base_version, last_processID = \

--- a/processing/base_creator.py
+++ b/processing/base_creator.py
@@ -186,7 +186,7 @@ class BASECreator():
         end_year = end_dt.year
         if end_dt.day == 1 and end_dt.month == 1:
             end_year -= 1
-        base_path = self.path/self.BASE_fname_fmt.format(
+        base_path = self.path / self.BASE_fname_fmt.format(
             sid=site_id, res=resolution,
             ver='version')
 

--- a/processing/base_creator.py
+++ b/processing/base_creator.py
@@ -121,7 +121,7 @@ class BASECreator():
                 if phase_III_output_path.is_absolute():
                     path = phase_III_output_path
                 else:
-                    path = self._cwd/phase_III_output
+                    path = self._cwd / phase_III_output
             if config.has_option(cfg_section, 'PI_vars'):
                 try:
                     PI_vars = ast.literal_eval(

--- a/processing/base_creator.py
+++ b/processing/base_creator.py
@@ -266,7 +266,7 @@ class BASECreator():
                 last_cdiac_HH=last_cdiac_HH, last_cdiac_HR=last_cdiac_HR)
             with open(f_path, 'r') as fp_in, open(base_path, 'w') as base:
                 self.create_BASE(fp_in, base, site_id, last_base_version)
-            md5sum = self.file_util.get_md5(base_path) # TODO: check this
+            md5sum = self.file_util.get_md5(base_path)
             base_path.unlink()
             new_base_version = self.assign_new_data_version(
                 resolution=res, last_base_version=last_base_version,

--- a/processing/base_creator.py
+++ b/processing/base_creator.py
@@ -1,4 +1,3 @@
-import os
 import ast
 from configparser import ConfigParser
 import csv
@@ -7,6 +6,7 @@ from db_handler import DBConfig, DBHandler, NewDBHandler
 from file_name_verifier import FileNameVerifier
 from fp_vars import FPVariables
 from logger import Logger
+from pathlib import Path
 from process_actions import ProcessActions
 from process_states import ProcessStates
 from report_status import ReportStatus
@@ -23,7 +23,7 @@ _log = Logger(True, None, None, _log_name_prefix).getLogger(_log_name_prefix)
 
 class BASECreator():
     def __init__(self):
-        self._cwd = os.getcwd()
+        self._cwd = Path.cwd()
         self.db_conn_pool = {}
         self.new_db_handler = NewDBHandler()
         self.init_status = self._get_params_from_config()
@@ -46,7 +46,7 @@ class BASECreator():
             conn.close()
 
     def _get_params_from_config(self):
-        with open(os.path.join(self._cwd, 'qaqc.cfg')) as cfg:
+        with open(self._cwd/'qaqc.cfg') as cfg:
             code_ver, code_major_ver, combined_files_loc, path, \
                 flux_hostname, flux_user, flux_auth, flux_db_name, PI_vars, \
                 new_db_config = self._read_config(cfg)
@@ -69,10 +69,8 @@ class BASECreator():
         if not path:
             print('No path for Phase III specified in config file')
             return False
-        elif not os.path.exists(path):
-            os.makedirs(path)
-            self.path = path
         else:
+            path.mkdir(parents=True, exist_ok=True)
             self.path = path
 
         if not all((flux_user, flux_auth, flux_db_name)):
@@ -119,10 +117,11 @@ class BASECreator():
         if config.has_section(cfg_section):
             if config.has_option(cfg_section, 'output_dir'):
                 phase_III_output = config.get(cfg_section, 'output_dir')
-                if os.path.abspath(phase_III_output):
-                    path = phase_III_output
+                phase_III_output_path = Path(phase_III_output)
+                if phase_III_output_path.is_absolute():
+                    path = phase_III_output_path
                 else:
-                    path = os.path.join(self._cwd, phase_III_output)
+                    path = self._cwd/phase_III_output
             if config.has_option(cfg_section, 'PI_vars'):
                 try:
                     PI_vars = ast.literal_eval(
@@ -187,10 +186,9 @@ class BASECreator():
         end_year = end_dt.year
         if end_dt.day == 1 and end_dt.month == 1:
             end_year -= 1
-        base_path = os.path.join(
-            self.path, self.BASE_fname_fmt.format(
-                sid=site_id, res=resolution,
-                ver='version'))
+        base_path = self.path/self.BASE_fname_fmt.format(
+            sid=site_id, res=resolution,
+            ver='version')
 
         return site_id, base_path, start_year, end_year, resolution
 
@@ -252,13 +250,13 @@ class BASECreator():
         return new_version
 
     def candidate_iterator(self, site_id, attr):
-        f = attr.get('full_path')
+        f_path = attr.get('full_path')
         base_path = attr.get('base_path')
         res = attr.get('res')
         file_attr = []
-        process_id = self.preBASE_files.get(f)
+        process_id = self.preBASE_files.get(str(f))
         try:
-            _log.info(f'Creating BASE files for candidate: {f}')
+            _log.info(f'Creating BASE files for candidate: {f_path.name}')
             last_base_version, last_processID = \
                 self.site_list.get(site_id, (None, None))
             last_cdiac_HH, last_cdiac_HR = self.historic_site_list.get(
@@ -266,22 +264,23 @@ class BASECreator():
             last_base_version, is_last_ver_cdiac = self.get_last_base_version(
                 resolution=res, last_base_version=last_base_version,
                 last_cdiac_HH=last_cdiac_HH, last_cdiac_HR=last_cdiac_HR)
-            with open(f, 'r') as fp_in, open(base_path, 'w') as base:
+            with open(f_path, 'r') as fp_in, open(base_path, 'w') as base:
                 self.create_BASE(fp_in, base, site_id, last_base_version)
-            md5sum = self.file_util.get_md5(base_path)
-            os.remove(base_path)
+            md5sum = self.file_util.get_md5(base_path) # TODO: check this
+            base_path.unlink()
             new_base_version = self.assign_new_data_version(
                 resolution=res, last_base_version=last_base_version,
                 last_processID=last_processID,
                 is_last_ver_cdiac=is_last_ver_cdiac, site_id=site_id,
                 md5sum=md5sum, processID=process_id)
-            new_base_path = base_path.replace('version', new_base_version)
-            with open(f, 'r') as fp_in, open(new_base_path, 'w') as base:
+            new_base_path = Path(str(base_path)
+                                 .replace('version', new_base_version))
+            with open(f_path, 'r') as fp_in, open(new_base_path, 'w') as base:
                 self.create_BASE(fp_in=fp_in, base=base, site_id=site_id,
                                  base_version=new_base_version)
             new_md5sum = self.file_util.get_md5(new_base_path)
-            size = os.path.getsize(new_base_path)
-            base_fname = os.path.basename(new_base_path)
+            size = new_base_path.stat().st_size
+            base_fname = new_base_path.name
             timestamp = datetime.datetime.now()
             file_attr = [size, new_md5sum, base_fname, timestamp,
                          new_base_path, new_base_version]
@@ -317,8 +316,9 @@ class BASECreator():
             self.new_db_handler.get_filename_checksum_lookup(psql_conn)
 
         for f, pid in self.preBASE_files.items():
-            base_candidate_name = os.path.basename(f)
-            _log.info(f'BASE candidate: {f}')
+            f_path = Path(f)
+            base_candidate_name = f_path.name
+            _log.info(f'BASE candidate: {base_candidate_name}')
             file_attrs = self.get_BASE_attrs(f)
             site_id = file_attrs[0]
             cur_file_res = file_attrs[-1]
@@ -343,7 +343,7 @@ class BASECreator():
             for k, v in zip(attr_keys, file_attrs[1:]):
                 _tmp[k] = v
             _tmp['base_candidate_name'] = base_candidate_name
-            _tmp['full_path'] = f
+            _tmp['full_path'] = f_path
             if site_id_attrs:
                 site_id_attrs.append(_tmp)
                 base_attrs[site_id] = site_id_attrs

--- a/processing/base_creator.py
+++ b/processing/base_creator.py
@@ -46,7 +46,7 @@ class BASECreator():
             conn.close()
 
     def _get_params_from_config(self):
-        with open(self._cwd/'qaqc.cfg') as cfg:
+        with open(self._cwd / 'qaqc.cfg') as cfg:
             code_ver, code_major_ver, combined_files_loc, path, \
                 flux_hostname, flux_user, flux_auth, flux_db_name, PI_vars, \
                 new_db_config = self._read_config(cfg)

--- a/processing/data_reader.py
+++ b/processing/data_reader.py
@@ -39,7 +39,7 @@ class DataReader:
 
         config = ConfigParser()
         try:
-            with open(Path.cwd()/'qaqc.cfg') as cfg:
+            with open(Path.cwd() / 'qaqc.cfg') as cfg:
                 config.read_file(cfg)
                 cfg_section = 'MANDATORY_VARIABLES'
                 if config.has_section(cfg_section):

--- a/processing/data_reader.py
+++ b/processing/data_reader.py
@@ -2,7 +2,6 @@
 
 import ast
 import numpy as np
-import os
 import string
 import sys
 import warnings
@@ -14,6 +13,7 @@ from file_name_verifier import FileNameVerifier
 from fp_vars import FPVariables
 from logger import Logger
 from messages import Messages
+from pathlib import Path
 from status import StatusGenerator
 from utils import DataUtil, TextUtil, VarUtil
 
@@ -38,9 +38,8 @@ class DataReader:
         self.mandatory_headers = None
 
         config = ConfigParser()
-        cwd = os.getcwd()
         try:
-            with open(os.path.join(cwd, 'qaqc.cfg')) as cfg:
+            with open(Path.cwd()/'qaqc.cfg') as cfg:
                 config.read_file(cfg)
                 cfg_section = 'MANDATORY_VARIABLES'
                 if config.has_section(cfg_section):
@@ -441,9 +440,9 @@ class DataReader:
         :param run_type: (o)riginal or (r)epaired file
         :return: list of status objects from each test
         """
-        self.filename = os.path.basename(file_path)
+        self.filename = Path(file_path).name
         _log.info(f'Data Reader checks initiated for {self.filename} '
-                  'as {run_type} file.')
+                  f'as {run_type} file.')
 
         # set up an empty list to receive the individual status obj
         statuses = []

--- a/processing/join_site_data.py
+++ b/processing/join_site_data.py
@@ -112,7 +112,7 @@ class JoinSiteData:
         return file_order, skip_list
 
     def join_site_files(self, proc_id, site_id, resolution, is_test=False):
-        dir_site_path = Path(self.data_dir)/site_id
+        dir_site_path = Path(self.data_dir) / site_id
         if not dir_site_path.is_dir():
             _log.fatal(f'Directory not found for site {site_id}.')
             return None, self.stat_gen.status_generator(
@@ -233,7 +233,7 @@ class JoinSiteData:
                             continue
                         if times.name in files:
                             continue
-                        files[times.name] = open(dir_site_path/times.name, 'r')
+                        files[times.name] = open(dir_site_path / times.name, 'r')
                         header_ln = files[times.name].readline().rstrip('\n')
                         potential_headers[times.name] = header_ln.split(',')
                     header_order = self.get_valid_variables(potential_headers)
@@ -244,7 +244,7 @@ class JoinSiteData:
                         f'{file_order[-1].end}-{file_name_timestamp}.csv')
                     temp_dir_path = Path(self.temp_dir)
                     temp_dir_path.mkdir(parents=True, exist_ok=True)
-                    file_path = temp_dir_path/out_file_name
+                    file_path = temp_dir_path / out_file_name
                     out_file = open(file_path, 'w')
                     out_file.write(','.join(header_order)+'\n')
                     sub_stat = {}

--- a/processing/join_site_data.py
+++ b/processing/join_site_data.py
@@ -26,7 +26,7 @@ class JoinSiteData:
         self.reporter = ReportStatus()
         self.stat_gen = status.StatusGenerator()
         config = ConfigParser()
-        with open(Path.cwd()/'qaqc.cfg') as cfg:
+        with open(Path.cwd() / 'qaqc.cfg') as cfg:
             config.read_file(cfg)
             cfg_section = 'PHASE_II'
             if config.has_section(cfg_section):

--- a/processing/join_site_data.py
+++ b/processing/join_site_data.py
@@ -3,12 +3,12 @@
 import argparse
 import collections
 import datetime
-import os
 import status
 
 from configparser import ConfigParser
 from file_name_verifier import FileNameVerifier
 from logger import Logger
+from pathlib import Path
 from report_status import ReportStatus
 from utils import VarUtil
 
@@ -26,8 +26,7 @@ class JoinSiteData:
         self.reporter = ReportStatus()
         self.stat_gen = status.StatusGenerator()
         config = ConfigParser()
-        cwd = os.getcwd()
-        with open(os.path.join(cwd, 'qaqc.cfg')) as cfg:
+        with open(Path.cwd()/'qaqc.cfg') as cfg:
             config.read_file(cfg)
             cfg_section = 'PHASE_II'
             if config.has_section(cfg_section):
@@ -113,21 +112,23 @@ class JoinSiteData:
         return file_order, skip_list
 
     def join_site_files(self, proc_id, site_id, resolution, is_test=False):
-        dir_name = os.path.join(self.data_dir, site_id)
-        if not os.path.isdir(dir_name):
-            _log.fatal(f'Directory not found {dir_name}.')
+        dir_site_path = Path(self.data_dir)/site_id
+        if not dir_site_path.is_dir():
+            _log.fatal(f'Directory not found for site {site_id}.')
             return None, self.stat_gen.status_generator(
                 _log, 'join_site_files',
-                status_msg=f'Directory not found {dir_name}.',
+                status_msg=f'Directory not found for site {site_id}.',
                 report_section='high_level'), None
         valid_files = self.reporter.get_available_base_input(site_id)
         dir_files = {}
-        for f in [f for f in os.listdir(dir_name)
-                  if os.path.isfile(os.path.join(dir_name, f))]:
-            if f not in valid_files:
+        file_paths = [file_path for file_path in dir_site_path.glob('*')
+                      if file_path.is_file()]
+        for file_path in file_paths:
+            file_name = file_path.name
+            if file_name not in valid_files:
                 continue
             fnv = FileNameVerifier()
-            fn_stat = fnv.driver(os.path.join(dir_name, f))
+            fn_stat = fnv.driver(str(file_path))
             if fn_stat.get_status_code() == status.StatusCode.OK:
                 if fnv.fname_attrs['site_id'] not in dir_files:
                     dir_files[fnv.fname_attrs['site_id']] = {}
@@ -148,10 +149,10 @@ class JoinSiteData:
                         start=fnv.fname_attrs['ts_start'],
                         end=fnv.fname_attrs['ts_end'],
                         upload=fnv.fname_attrs.get('ts_upload', ''),
-                        name=f, status=fn_stat,
-                        proc_id=valid_files[f]['process_id'],
-                        original_name=valid_files[f]['original_name'],
-                        prior_proc_id=valid_files[f]['prior_process_id']))
+                        name=file_name, status=fn_stat,
+                        proc_id=valid_files[file_name]['process_id'],
+                        original_name=valid_files[file_name]['original_name'],
+                        prior_proc_id=valid_files[file_name]['prior_process_id']))
         for site_id, site in dir_files.items():
             for res, res_data in site.items():
                 if res != resolution:
@@ -232,8 +233,7 @@ class JoinSiteData:
                             continue
                         if times.name in files:
                             continue
-                        files[times.name] = open(os.path.join(
-                            dir_name, times.name), 'r')
+                        files[times.name] = open(dir_site_path/times.name, 'r')
                         header_ln = files[times.name].readline().rstrip('\n')
                         potential_headers[times.name] = header_ln.split(',')
                     header_order = self.get_valid_variables(potential_headers)
@@ -242,9 +242,9 @@ class JoinSiteData:
                     out_file_name = (
                         f'{site_id}_{res}_{file_order[0].start}_'
                         f'{file_order[-1].end}-{file_name_timestamp}.csv')
-                    if not os.path.isdir(self.temp_dir):
-                        os.makedirs(self.temp_dir)
-                    file_path = os.path.join(self.temp_dir, out_file_name)
+                    temp_dir_path = Path(self.temp_dir)
+                    temp_dir_path.mkdir(parents=True, exist_ok=True)
+                    file_path = temp_dir_path/out_file_name
                     out_file = open(file_path, 'w')
                     out_file.write(','.join(header_order)+'\n')
                     sub_stat = {}

--- a/processing/test/test_path.py
+++ b/processing/test/test_path.py
@@ -89,20 +89,25 @@ def test_data_reader(data_reader, caplog):
         assert '\\' not in captured[1] or '/' not in captured[1]
 
 
-def mock_messages_init(dummyself):
-    dummyself.msgs = []
-    dummyself.checknames = {}
+def mock_messages_init(dummyvar):
+    pass
+
+
+def mock_msg_get_display_check(*args):
+    return 'Display name for QA/QC check not found.'
 
 
 @pytest.fixture
 def file_name_verifier(monkeypatch):
 
     monkeypatch.setattr(Messages, '__init__', mock_messages_init)
+    monkeypatch.setattr(Messages, 'get_display_check',
+                        mock_msg_get_display_check)
 
     return FileNameVerifier()
 
 
-def test_file_name_verifier(file_name_verifier, caplog):
+def test_file_name_verifier_windows_path(file_name_verifier, caplog):
     test_path = PureWindowsPath('D:\\test\\test_file.csv')
     caplog.clear()
     with caplog.at_level(logging.INFO):
@@ -113,6 +118,7 @@ def test_file_name_verifier(file_name_verifier, caplog):
 
     test_path = PurePosixPath('/home/test/test_file.csv')
     caplog.clear()
+    file_name_verifier.__init__()
     with caplog.at_level(logging.INFO):
         file_name_verifier.driver(test_path)
         captured = [rec.message for rec in caplog.records]

--- a/processing/test/test_path.py
+++ b/processing/test/test_path.py
@@ -1,13 +1,11 @@
-from data_reader import DataReader
-from fp_vars import FPVariables
-from logger import Logger
-from status import Status
 import pytest
-from pathlib import PureWindowsPath, PurePosixPath
 import logging
+
+from data_reader import DataReader
 from file_name_verifier import FileNameVerifier
+from fp_vars import FPVariables
+from pathlib import PureWindowsPath, PurePosixPath
 from messages import Messages
-from site_attrs import SiteAttributes
 
 __author__ = 'Sy-Toan Ngo'
 __email__ = 'sytoanngo@lbl.gov'
@@ -23,26 +21,33 @@ def mock_FPVariables_get_fp_vars_dict(dummyself):
 def mock_FPVariables_load_fp_vars_dict(dummyself):
     return {}
 
+
 def mock_read_single_file(self, file_path, check_log, usemask=True,
                           missing_values='-9999',
                           datatype=None, usecols=None):
-        check_log.info(f'Reading in single file with filename {self.filename}')
-        return []
+    check_log.info(f'Reading in single file with filename {self.filename}')
+    return []
+
 
 def mock__check_timestamp_header(self, header, check_log):
     return []
 
+
 def mock__check_all_headers_quotes(self, header_as_is, check_log):
     return []
+
 
 def mock__check_data_header(self, header_as_is, check_log):
     return []
 
+
 def mock__check_any_valid_header(self, check_log):
     return []
 
+
 def mock__check_mandatory_data_headers(self, check_log):
     return []
+
 
 @pytest.fixture
 def data_reader(monkeypatch):
@@ -64,6 +69,7 @@ def data_reader(monkeypatch):
                         mock__check_mandatory_data_headers)
     ff = DataReader(test_mode=True)
     return ff
+
 
 def test_data_reader(data_reader, caplog):
     test_path = PureWindowsPath('D:\\test\\test_file.csv')
@@ -94,6 +100,7 @@ def file_name_verifier(monkeypatch):
     monkeypatch.setattr(Messages, '__init__', mock_messages_init)
 
     return FileNameVerifier()
+
 
 def test_file_name_verifier(file_name_verifier, caplog):
     test_path = PureWindowsPath('D:\\test\\test_file.csv')

--- a/processing/test/test_path.py
+++ b/processing/test/test_path.py
@@ -1,0 +1,113 @@
+from data_reader import DataReader
+from fp_vars import FPVariables
+from logger import Logger
+from status import Status
+import pytest
+from pathlib import PureWindowsPath, PurePosixPath
+import logging
+from file_name_verifier import FileNameVerifier
+from messages import Messages
+from site_attrs import SiteAttributes
+
+__author__ = 'Sy-Toan Ngo'
+__email__ = 'sytoanngo@lbl.gov'
+
+log = logging.Logger('test')
+
+
+def mock_FPVariables_get_fp_vars_dict(dummyself):
+    return {'FC': 'dummy',
+            'TIMESTAMP_END': 'dummy', 'TIMESTAMP_START': 'dummy'}
+
+
+def mock_FPVariables_load_fp_vars_dict(dummyself):
+    return {}
+
+def mock_read_single_file(self, file_path, check_log, usemask=True,
+                          missing_values='-9999',
+                          datatype=None, usecols=None):
+        check_log.info(f'Reading in single file with filename {self.filename}')
+        return []
+
+def mock__check_timestamp_header(self, header, check_log):
+    return []
+
+def mock__check_all_headers_quotes(self, header_as_is, check_log):
+    return []
+
+def mock__check_data_header(self, header_as_is, check_log):
+    return []
+
+def mock__check_any_valid_header(self, check_log):
+    return []
+
+def mock__check_mandatory_data_headers(self, check_log):
+    return []
+
+@pytest.fixture
+def data_reader(monkeypatch):
+    monkeypatch.setattr(FPVariables, '_load_fp_vars_dict',
+                        mock_FPVariables_load_fp_vars_dict)
+    monkeypatch.setattr(FPVariables, 'get_fp_vars_dict',
+                        mock_FPVariables_get_fp_vars_dict)
+    monkeypatch.setattr(DataReader, 'read_single_file',
+                        mock_read_single_file)
+    monkeypatch.setattr(DataReader, '_check_timestamp_header',
+                        mock__check_timestamp_header)
+    monkeypatch.setattr(DataReader, '_check_all_headers_quotes',
+                        mock__check_all_headers_quotes)
+    monkeypatch.setattr(DataReader, '_check_data_header',
+                        mock__check_data_header)
+    monkeypatch.setattr(DataReader, '_check_any_valid_header',
+                        mock__check_any_valid_header)
+    monkeypatch.setattr(DataReader, '_check_mandatory_data_headers',
+                        mock__check_mandatory_data_headers)
+    ff = DataReader(test_mode=True)
+    return ff
+
+def test_data_reader(data_reader, caplog):
+    test_path = PureWindowsPath('D:\\test\\test_file.csv')
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        data_reader.driver(test_path, 'o')
+        captured = [rec.message for rec in caplog.records]
+        assert '\\' not in captured[0] or '/' not in captured[0]
+        assert '\\' not in captured[1] or '/' not in captured[1]
+
+    test_path = PurePosixPath('/home/test/test_file.csv')
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        data_reader.driver(test_path, 'o')
+        captured = [rec.message for rec in caplog.records]
+        assert '\\' not in captured[0] or '/' not in captured[0]
+        assert '\\' not in captured[1] or '/' not in captured[1]
+
+
+def mock_messages_init(dummyself):
+    dummyself.msgs = []
+    dummyself.checknames = {}
+
+
+@pytest.fixture
+def file_name_verifier(monkeypatch):
+
+    monkeypatch.setattr(Messages, '__init__', mock_messages_init)
+
+    return FileNameVerifier()
+
+def test_file_name_verifier(file_name_verifier, caplog):
+    test_path = PureWindowsPath('D:\\test\\test_file.csv')
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        file_name_verifier.driver(test_path)
+        captured = [rec.message for rec in caplog.records]
+        assert '\\' not in captured[0] or '/' not in captured[0]
+        assert '\\' not in captured[1] or '/' not in captured[1]
+
+    test_path = PurePosixPath('/home/test/test_file.csv')
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        file_name_verifier.driver(test_path)
+        captured = [rec.message for rec in caplog.records]
+        assert '\\' not in captured[0] or '/' not in captured[0]
+        assert '\\' not in captured[1] or '/' not in captured[1]

--- a/processing/upload_checks.py
+++ b/processing/upload_checks.py
@@ -325,9 +325,9 @@ def main():
 
 
 def copy_file(args, fnv):
-    site_path = Path.cwd()/fnv.fname_attrs['site_id']
+    site_path = Path.cwd() / fnv.fname_attrs['site_id']
     site_path.mkdir(parents=True, exist_ok=True)
-    copyfile(args.filename, site_path/Path(args.filename).name)
+    copyfile(args.filename, site_path / Path(args.filename).name)
 
 if __name__ == "__main__":
     main()

--- a/processing/upload_checks.py
+++ b/processing/upload_checks.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import argparse
-import os
 import traceback
 from time import time
 from data_reader import DataReader
@@ -10,6 +9,7 @@ from logger import Logger
 from status import StatusCode, StatusGenerator  # , StatusEncoder
 from timestamp_checks import TimestampChecks
 from gap_fill import GapFilled
+from pathlib import Path
 from process_status import ProcessStatus
 from process_states import ProcessStates
 from process_actions import ProcessActions
@@ -61,7 +61,8 @@ def main():
 
         original_filename = FilenameUtils().remove_upload_timestamp(
             args.filename)
-        fname_ext = os.path.splitext(original_filename)[1]
+        original_filename_path = Path(original_filename)
+        fname_ext = original_filename_path.suffix
         d = DataReader()
         fnv = FileNameVerifier()  # keep status updated
 
@@ -150,11 +151,11 @@ def main():
             args.run_type = 'z'
             d.original_header = [('Header information not available from '
                                   'archival file type (e.g., zip, 7z).')]
-            zip_filename = os.path.basename(original_filename)
+            zip_filename = original_filename_path.name
             zip_log = Logger().getLogger('zip_file')
             zip_qaqc_check = msg.get_display_check(zip_log.getName())
             zip_log.warning(
-                f'file {original_filename} is standard archival format')
+                f'file {zip_filename} is standard archival format')
             statuses.append(StatusGenerator().status_generator(
                 logger=zip_log, qaqc_check=zip_qaqc_check,
                 status_msg=zip_filename, report_type='single_list'))
@@ -279,7 +280,7 @@ def main():
                 if process_status_code < StatusCode.OK:
                     status_msg += (' Data will be queued for '
                                    'further data processing.')
-        original_filename_basename = os.path.basename(original_filename)
+        original_filename_basename = original_filename_path.name
         report_title = f'{title_prefix}{original_filename_basename}'
         for stat in statuses:  # make this a method??
             sc = stat.get_status_code()
@@ -324,16 +325,9 @@ def main():
 
 
 def copy_file(args, fnv):
-    if not os.path.exists(os.path.join(os.getcwd(),
-                                       fnv.fname_attrs['site_id'])):
-        try:
-            os.makedirs(os.path.join(os.getcwd(), fnv.fname_attrs['site_id']))
-        except Exception:
-            pass
-    copyfile(
-        args.filename, os.path.join(os.getcwd(), fnv.fname_attrs['site_id'],
-                                    os.path.basename(args.filename)))
-
+    site_path = Path.cwd()/fnv.fname_attrs['site_id']
+    site_path.mkdir(parents=True, exist_ok=True)
+    copyfile(args.filename, site_path/Path(args.filename).name)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Using os.path.basename() to get the file name is inconsistent across platforms.

In Windows, file paths typically use backslashes (\\) as the path separator, whereas in Python, the os.path module treats both forward slashes (/) and backslashes (\\) as valid path separators.

However, when using os.path.basename() on Windows paths, you might encounter issues if the path uses backslashes and you're running the code in a Unix-like environment, such as macOS or Linux. In such cases, os.path.basename() might not correctly handle the backslashes, leading to unexpected results.

To ensure platform compatibility when dealing with Windows paths, it's recommended to use pathlib instead, as it provides a more consistent and platform-independent approach.

## PR Self Evaluation

- [x] I have reviewed my code to check that it contains no sensitive information.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests or modified existing tests that prove my fix is effective or that my feature works
- [x] Existing unit tests pass locally with my changes

