### PR TITLE
Add testing for upload_checks; fix logging when called via method

### DIFF
--- a/processing/data_missing.py
+++ b/processing/data_missing.py
@@ -52,6 +52,7 @@ class DataMissing:
         """
         statuses = []
         _log.info("Beginning to run all_missing_data_detection algorithm...")
+        _log.resetStats()
         gap_list, number_data_variables = self.all_missing_data_detection(
             data_reader)
         if self.status_msg_parts:

--- a/processing/data_reader.py
+++ b/processing/data_reader.py
@@ -443,6 +443,7 @@ class DataReader:
         self.filename = Path(file_path).name
         _log.info(f'Data Reader checks initiated for {self.filename} '
                   f'as {run_type} file.')
+        _log.resetStats()
 
         # set up an empty list to receive the individual status obj
         statuses = []

--- a/processing/db_handler.py
+++ b/processing/db_handler.py
@@ -260,6 +260,7 @@ class NewDBHandler:
 
         conn = self.init_db_conn(db_config)
         process_id = self._register_qaqc_process(conn, field_names, values)
+        conn.close()
 
         return process_id
 

--- a/processing/file_fixer.py
+++ b/processing/file_fixer.py
@@ -891,7 +891,7 @@ class FileFixer:
                                                process_id, site_id)
                 else:
                     autorepair_uuid = 'test-autorepair-uuid'
-                    is_upload_successful = None
+                    is_upload_successful = True
                 msg = 'File was Autocorrected and corrected file uploaded.'
                 self.append_status_msg_parts('warning', msg)
                 return autorepair_filename, None, \

--- a/processing/gap_fill.py
+++ b/processing/gap_fill.py
@@ -109,6 +109,7 @@ class GapFilled:
             specific to this class
         """
         _log.info("Beginning to run gap_fill_detection algorithm...")
+        _log.resetStats()
 
         if qaqc_mode == 'format':
             sub_log1 = _log

--- a/processing/missing_value_format.py
+++ b/processing/missing_value_format.py
@@ -77,6 +77,7 @@ class MissingValueFormat:
         :param fname:
         :return:
         """
+        _log.resetStats()
         report_type = 'single_msg'
         dr = DataReader()
         if d.data is not None:

--- a/processing/test/test_upload_checks.py
+++ b/processing/test/test_upload_checks.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+from upload_checks import upload_checks
+import getpass
+import json
+import pytest
+
+__author__ = 'Danielle Christianson'
+__email__ = 'dschristianson@lbl.gov'
+
+
+def mock_getpass_getuser():
+    return 'unittester'
+
+
+def parse_json(filepath):
+    var_values = []
+    ids = []
+
+    with open(file=filepath, mode='r') as f:
+        cases = json.load(f)
+
+        for key, details in cases.items():
+            var_values.append((key,
+                               details.get('run_type'),
+                               details.get('output')))
+            ids.append(key.split('.')[0])
+
+    return var_values, ids
+
+
+var_values, ids = parse_json(
+    filepath='./test/testdata/format_qaqc/integration_cases.json')
+
+
+@pytest.mark.parametrize('filename, run_type, output', var_values, ids=ids)
+def test_upload_checks(filename, run_type, output, capsys, monkeypatch):
+
+    monkeypatch.setattr(getpass, 'getuser', mock_getpass_getuser)
+
+    filepath = Path().cwd() / 'test/testdata/format_qaqc' / filename
+    process_id, is_upload_successful, upload_uuid = upload_checks(
+        filename=str(filepath), upload_id=99999999, run_type=run_type,
+        site_id='US-UMB', prior_process_id=None, zip_process_id=None,
+        local_run=True)
+    captured = capsys.readouterr()
+    print_output = captured.out
+    print_list = print_output.split('\n')
+
+    assert process_id == 999999
+    assert is_upload_successful is output.get('is_upload_successful')
+
+    expected_upload_uuid = output.get('upload_uuid')
+    if expected_upload_uuid is not None:
+        assert upload_uuid == expected_upload_uuid
+    else:
+        assert upload_uuid is None
+
+    # last item is empty str
+    ts_end_expected = output.get('data_timestamp_end')
+    ts_start_expected = output.get('data_timestamp_start')
+
+    if ts_end_expected is not None:
+        assert print_list[-2] == output.get('data_timestamp_end')
+    else:
+        assert print_list[-2] == 'None'
+
+    if ts_start_expected is not None:
+        assert print_list[-3] == output.get('data_timestamp_start')
+    else:
+        assert print_list[-3] == 'None'
+
+    report_expected = json.dumps(output.get('report'))
+    assert print_list[-4] == report_expected

--- a/processing/test/test_upload_checks.py
+++ b/processing/test/test_upload_checks.py
@@ -43,7 +43,17 @@ def test_upload_checks(filename, run_type, output, capsys, monkeypatch):
         site_id='US-UMB', prior_process_id=None, zip_process_id=None,
         local_run=True)
     captured = capsys.readouterr()
+    # Capture the print statements from the case; reads from the last read
     print_output = captured.out
+    # Convert captured print statements into a list based on line breaks
+    #   Example print list -- for last entries, see print statements
+    #   at end of upload_checks function if local_run=True (~ln=355)
+    #   [ ...,  # we don't care what is written at beginning of list
+    #     <json_report>,
+    #     <YYYY-MM-DD HH:MM or None>,
+    #     <YYYY-MM-DD HH:MM or None>,
+    #     ''
+    #   ]
     print_list = print_output.split('\n')
 
     assert process_id == 999999

--- a/processing/test/testdata/format_qaqc/integration_cases.json
+++ b/processing/test/testdata/format_qaqc/integration_cases.json
@@ -1,0 +1,10772 @@
+{
+    "US-UMB_HR_200001011000_200001012000.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. No issues were encountered. Data will be queued for further data processing.",
+                    "status_code": "OK"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000.csv"
+                },
+                "check_summary": {},
+                "checks": [],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_NS.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_NS.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: optional parameter (NS) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_filenameverifier.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_filenameverifier.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: optional parameter (filenameverifier) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_2000010120.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_2000010120.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "ts-end (end time)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Do filename time components match file time period?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "TIMESTAMP_END 200001012000 does not match filename ts-end time 2000010120"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: ts-end (end time)",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_000010100000_200001012000.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_000010100000_200001012000.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "ts-start (start time)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Do filename time components match file time period?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "TIMESTAMP_START 200001010000 does not match filename ts-start time 000010100000"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: ts-start (start time)",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UM1_H_200010100000_200001012000.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UM1_H_200010100000_200001012000.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "SITE_ID, resolution"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Do filename time components match file time period?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "TIMESTAMP_START 200001010000 does not match filename ts-start time 200010100000"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Is Timestamp resolution OK?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename resolution not valid. Timestamp resolution verification is INCOMPLETE."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename components fixed: SITE_ID; resolution; ts-start (start time)",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_NS_extra.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_NS_extra.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "incorrect number of components (expect timestamp errors)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Do filename time components match file time period?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "TIMESTAMP_START 200001010000 does not match filename ts-start time None, TIMESTAMP_END 200001012000 does not match filename ts-end time None"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Is Timestamp resolution OK?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename resolution not valid. Timestamp resolution verification is INCOMPLETE."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename had incorrect number of components. Fixed filename as described below.",
+                                    "Filename components fixed: SITE_ID; resolution; ts-start (start time); ts-end (end time)",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HH_200001010000_200001012000.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HH_200001010000_200001012000.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Timestamp resolution OK?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "19",
+                                    "19",
+                                    "1"
+                                ],
+                                "status_body": [
+                                    "  timestamps in  in TIMESTAMP_START have invalid resolution between within or between rows",
+                                    "  timestamps in  in TIMESTAMP_END have invalid resolution between within or between rows",
+                                    "  timestamp in  have invalid resolution within within or between rows"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: resolution",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200002012000.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200002012000.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Do filename time components match file time period?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "TIMESTAMP_END 200001012000 does not match filename ts-end time 200002012000"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: ts-end (end time)",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000.txt": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.txt"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000.txt"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "extension is not csv"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Changed .txt extension to .csv.",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.txt"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-U_HR_200001010000_200001012000.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-U_HR_200001010000_200001012000.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "SITE_ID"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: SITE_ID",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_notcsv.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "Problem while loading data file; QA/QC INCOMPLETE. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START;TIMESTAMP_END;USTAR;TA_1_1_1;WD;WS;FC_1_1_1;SC;H_1_1_1;LE_1_1_1;TS_1_1_1;TS_1_2_1;P;RH_1_1_1;PA_1_1_1;CO2_1_1_1;SWC_1_1_1;NETRAD;PPFD_IN;SW_IN;SW_OUT;LW_IN;LW_OUT;TA_1_1_2;TA_1_1_3;SWC_1_1_3;SWC_1_1_2;RH_1_1_2;LE_1_1_2;PA_1_1_2;FC_1_1_2;CO2_1_1_2;FETCH_FILTER;FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_notcsv.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any problems reading file?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Error reading data from the file. ."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables as expected?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    " These unexpected variables were found in columns 1 & 2 instead of TIMESTAMP_START and TIMESTAMP_END: "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP_START;TIMESTAMP_END;USTAR;TA_1_1_1;WD;WS;FC_1_1_1;SC;H_1_1_1;LE_1_1_1;TS_1_1_1;TS_1_2_1;P;RH_1_1_1;PA_1_1_1;CO2_1_1_1;SWC_1_1_1;NETRAD;PPFD_IN;SW_IN;SW_OUT;LW_IN;LW_OUT;TA_1_1_2;TA_1_1_3;SWC_1_1_3;SWC_1_1_2;RH_1_1_2;LE_1_1_2;PA_1_1_2;FC_1_1_2;CO2_1_1_2;FETCH_FILTER;FC_SSITC_TEST"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP_START;TIMESTAMP_END;USTAR;TA_1_1_1;WD;WS;FC_1_1_1;SC;H_1_1_1;LE_1_1_1;TS_1_1_1;TS_1_2_1;P;RH_1_1_1;PA_1_1_1;CO2_1_1_1;SWC_1_1_1;NETRAD;PPFD_IN;SW_IN;SW_OUT;LW_IN;LW_OUT;TA_1_1_2;TA_1_1_3;SWC_1_1_3;SWC_1_1_2;RH_1_1_2;LE_1_1_2;PA_1_1_2;FC_1_1_2;CO2_1_1_2;FETCH_FILTER;FC_SSITC_TEST"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are any standard AmeriFlux Data Variable names present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "No data variables in the standard AmeriFlux format are present."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are primary flux Data Variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "None of the primary flux variables (FC or FCH4, LE, H) are present."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Unable to locate variable names. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_notcsv2.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "Problem while loading data file; QA/QC INCOMPLETE. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START\tTIMESTAMP_END\tUSTAR\tTA_1_1_1\tWD\tWS\tFC_1_1_1\tSC\tH_1_1_1\tLE_1_1_1\tTS_1_1_1\tTS_1_2_1\tP\tRH_1_1_1\tPA_1_1_1\tCO2_1_1_1\tSWC_1_1_1\tNETRAD\tPPFD_IN\tSW_IN\tSW_OUT\tLW_IN\tLW_OUT\tTA_1_1_2\tTA_1_1_3\tSWC_1_1_3\tSWC_1_1_2\tRH_1_1_2\tLE_1_1_2\tPA_1_1_2\tFC_1_1_2\tCO2_1_1_2\tFETCH_FILTER\tFC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_notcsv2.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any problems reading file?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Error reading data from the file. ."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables as expected?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    " These unexpected variables were found in columns 1 & 2 instead of TIMESTAMP_START and TIMESTAMP_END: "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP_START\tTIMESTAMP_END\tUSTAR\tTA_1_1_1\tWD\tWS\tFC_1_1_1\tSC\tH_1_1_1\tLE_1_1_1\tTS_1_1_1\tTS_1_2_1\tP\tRH_1_1_1\tPA_1_1_1\tCO2_1_1_1\tSWC_1_1_1\tNETRAD\tPPFD_IN\tSW_IN\tSW_OUT\tLW_IN\tLW_OUT\tTA_1_1_2\tTA_1_1_3\tSWC_1_1_3\tSWC_1_1_2\tRH_1_1_2\tLE_1_1_2\tPA_1_1_2\tFC_1_1_2\tCO2_1_1_2\tFETCH_FILTER\tFC_SSITC_TEST"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP_START\tTIMESTAMP_END\tUSTAR\tTA_1_1_1\tWD\tWS\tFC_1_1_1\tSC\tH_1_1_1\tLE_1_1_1\tTS_1_1_1\tTS_1_2_1\tP\tRH_1_1_1\tPA_1_1_1\tCO2_1_1_1\tSWC_1_1_1\tNETRAD\tPPFD_IN\tSW_IN\tSW_OUT\tLW_IN\tLW_OUT\tTA_1_1_2\tTA_1_1_3\tSWC_1_1_3\tSWC_1_1_2\tRH_1_1_2\tLE_1_1_2\tPA_1_1_2\tFC_1_1_2\tCO2_1_1_2\tFETCH_FILTER\tFC_SSITC_TEST"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are any standard AmeriFlux Data Variable names present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "No data variables in the standard AmeriFlux format are present."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are primary flux Data Variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "None of the primary flux variables (FC or FCH4, LE, H) are present."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Unable to locate variable names. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_bad1.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_PI, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, PREC, RH_1_1_1, PA_1_1_1_F, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_bad1.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "TA_1_1_PI, PREC, PA_1_1_1_F, RH1_1_2"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Fixed invalid variable name PA_1_1_1_F with PA_F_1_1_1: re-ordered qualifiers",
+                                    "NOTE un-fixable variable names: TA_1_1_PI; PREC; RH1_1_2",
+                                    "Filename component fixed: optional parameter (bad1) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_bad2.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, USTAR, WD, WD, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_1_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_bad2.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any duplicate Variable names?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "1 additional instance of USTAR temporarily renamed to USTAR_d1; ",
+                                    "1 additional instance of WD temporarily renamed to WD_d1; ",
+                                    "1 additional instance of TS_1_1_1 temporarily renamed to TS_1_1_1_d1. ",
+                                    ""
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "File has duplicate variables USTAR (column 4); WD (column 6); TS_1_1_1 (column 12).",
+                                    "File had issues that could not be automatically corrected. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_bad3.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "START_TIMESTAMP, END_TIMESTAMP, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_bad3.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables as expected?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    " These unexpected variables were found in columns 1 & 2 instead of TIMESTAMP_START and TIMESTAMP_END: "
+                                ],
+                                "status_body": [
+                                    "START_TIMESTAMP, END_TIMESTAMP"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "START_TIMESTAMP, END_TIMESTAMP"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [
+                                    "Expected timestamp variable(s) "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP_START, TIMESTAMP_END"
+                                ],
+                                "status_suffix": [
+                                    " is / are missing."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Fixed invalid variable name START_TIMESTAMP with TIMESTAMP_START: found synonym",
+                                    "Fixed invalid variable name END_TIMESTAMP with TIMESTAMP_END: found synonym",
+                                    "Filename component fixed: optional parameter (bad3) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad4.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "CO2_1_1_3, TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad4.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables as expected?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    " These unexpected variables were found in columns 1 & 2 instead of TIMESTAMP_START and TIMESTAMP_END: "
+                                ],
+                                "status_body": [
+                                    "CO2_1_1_3, TIMESTAMP_START"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Moved TIMESTAMP_START and/or TIMESTAMP_END into first two columns.",
+                                    "Filename component fixed: optional parameter (bad4) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad5.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad5.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamps in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "10",
+                                    "10"
+                                ],
+                                "status_body": [
+                                    " timestamps in TIMESTAMP_START have invalid format (YYYYMMDDHHMM is standard AmeriFlux format).",
+                                    " timestamps in TIMESTAMP_END have invalid format (YYYYMMDDHHMM is standard AmeriFlux format)."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Set 20 timestamps to minute resolution (YYYYMMDDHHMM is standard AmeriFlux FP-In format).",
+                                    "Filename component fixed: optional parameter (bad5) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad6.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad6.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables as expected?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    " These unexpected variables were found in columns 1 & 2 instead of TIMESTAMP_START and TIMESTAMP_END: "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP_END, USTAR"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [
+                                    "Expected timestamp variable(s) "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP_START"
+                                ],
+                                "status_suffix": [
+                                    " is / are missing."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Generated TIMESTAMP_START from TIMESTAMP_END variable.",
+                                    "Filename component fixed: optional parameter (bad6) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad7.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad7.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Is Timestamp resolution OK?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "1",
+                                    "1"
+                                ],
+                                "status_body": [
+                                    "  timestamp in  in TIMESTAMP_START have invalid resolution between within or between rows",
+                                    "  timestamp in  in TIMESTAMP_END have invalid resolution between within or between rows"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables with ALL Data Missing?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variables have all data missing: "
+                                ],
+                                "status_body": [
+                                    "LE_1_1_2"
+                                ],
+                                "status_suffix": [
+                                    ". Previously uploaded data with the same time period will be overwritten."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filled 1 timestamp gap with missing data values (-9999).",
+                                    "Filename component fixed: optional parameter (bad7) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad8.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad8.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Is Timestamp resolution OK?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "2",
+                                    "1"
+                                ],
+                                "status_body": [
+                                    "  timestamps in  in TIMESTAMP_START have invalid resolution between within or between rows",
+                                    "  timestamp in  have invalid resolution within within or between rows"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING",
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filled 1 timestamp gap with missing data values (-9999).",
+                                    "Filename component fixed: optional parameter (bad8) removed from filename"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            },
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Unable to validate timestamps for 1 lines (including any duplicated timestamps reported above). These lines were removed. Gap-filling may have occurred to fill any resulting missing timestamps. However more than 1% of file data was changed and QA/QC will not be continued.",
+                                    "File had issues that could not be automatically corrected. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad9.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad9.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamps in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "3",
+                                    "3"
+                                ],
+                                "status_body": [
+                                    " timestamps in TIMESTAMP_START have invalid format (YYYYMMDDHHMM is standard AmeriFlux format).",
+                                    " timestamps in TIMESTAMP_END have invalid format (YYYYMMDDHHMM is standard AmeriFlux format)."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables with ALL Data Missing?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variables have all data missing: "
+                                ],
+                                "status_body": [
+                                    "LE_1_1_1, SWC_1_1_1, SW_OUT, LW_IN, LW_OUT, SWC_1_1_3, SWC_1_1_2, LE_1_1_2"
+                                ],
+                                "status_suffix": [
+                                    ". Previously uploaded data with the same time period will be overwritten."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING",
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filled 1 timestamp gap with missing data values (-9999).",
+                                    "Filename component fixed: optional parameter (bad9) removed from filename"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            },
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Unable to validate timestamps for 3 lines (including any duplicated timestamps reported above). These lines were removed. Gap-filling may have occurred to fill any resulting missing timestamps. However more than 1% of file data was changed and QA/QC will not be continued.",
+                                    "File had issues that could not be automatically corrected. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001010000_200001010600_bad10.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001010600.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2",
+                    "upload_filename": "US-UMB_HR_200001010000_200001010600_bad10.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Is all Data Missing?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "All 30 data variables found in the file have only missing values. Previously uploaded data with the same time period will be overwritten."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables with ALL Data Missing?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variables have all data missing: "
+                                ],
+                                "status_body": [
+                                    "USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2"
+                                ],
+                                "status_suffix": [
+                                    ". Previously uploaded data with the same time period will be overwritten."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: optional parameter (bad10) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 06:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_bad12.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "Problem while loading data file; QA/QC INCOMPLETE. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_bad12.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any problems reading file?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Error reading data from the file. ."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Number of variables does not match number of data columns. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad13.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011100_200001012100.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad13.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables as expected?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    " These unexpected variables were found in columns 1 & 2 instead of TIMESTAMP_START and TIMESTAMP_END: "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP, USTAR"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [
+                                    "Expected timestamp variable(s) "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP_START, TIMESTAMP_END"
+                                ],
+                                "status_suffix": [
+                                    " is / are missing."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "NOTE un-fixable variable name: TIMESTAMP",
+                                    "Generated timestamp variables TIMESTAMP_START and TIMESTAMP_END from TIMESTAMP variables assuming data was reporting at the beginning of the half hour. This automated fix is only available temporarily.",
+                                    "Filename components fixed: ts-start (start time); ts-end (end time); optional parameter (bad13) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC_QC, H_1_1_1, LE_1_1_2, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Any duplicate Variable names?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "1 additional instance of LE_1_1_2 temporarily renamed to LE_1_1_2_d1. ",
+                                    ""
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "SC_QC"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Do filename time components match file time period?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "TIMESTAMP_START 200001011000 does not match filename ts-start time 200001010000"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Is Timestamp resolution OK?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "2",
+                                    "1"
+                                ],
+                                "status_body": [
+                                    "  timestamps in  in TIMESTAMP_START have invalid resolution between within or between rows",
+                                    "  timestamp in  have invalid resolution within within or between rows"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING",
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "NOTE un-fixable variable name: SC_QC",
+                                    "Filled 1 timestamp gap with missing data values (-9999)."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            },
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Unable to validate timestamps for 1 lines (including any duplicated timestamps reported above). These lines were removed. Gap-filling may have occurred to fill any resulting missing timestamps. However more than 1% of file data was changed and QA/QC will not be continued.",
+                                    "File has duplicate variables LE_1_1_2 (column 29).",
+                                    "File had issues that could not be automatically corrected. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad14.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad14.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any invalid Missing-Value Formats?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "Missing values are not indicated with -9999 for these variables (number of timestamps): "
+                                ],
+                                "status_body": [
+                                    "USTAR (2), TA_1_1_1 (1), WD (2), WS (2), FC_1_1_1 (3), SC (3), H_1_1_1 (2), LE_1_1_1 (8), TS_1_1_1 (1), TS_1_2_1 (1), P (1), RH_1_1_1 (1), PA_1_1_1 (1), CO2_1_1_1 (3), SWC_1_1_1 (9), NETRAD (1), PPFD_IN (1), SW_IN (1), SW_OUT (9), LW_IN (9), LW_OUT (9), TA_1_1_2 (1), TA_1_1_3 (1), SWC_1_1_3 (9), SWC_1_1_2 (9), RH_1_1_2 (1), LE_1_1_2 (9), PA_1_1_2 (1), FC_1_1_2 (3), CO2_1_1_2 (3), FETCH_FILTER (1), FC_SSITC_TEST (1)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Changed 109 missing values to -9999 from 109 instances of -6999.",
+                                    "Filename component fixed: optional parameter (bad14) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad15.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad15.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any invalid Missing-Value Formats?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "Missing values are not indicated with -9999 for these variables (number of timestamps): "
+                                ],
+                                "status_body": [
+                                    "USTAR (2), TA_1_1_1 (1), WD (2), WS (2), FC_1_1_1 (3), SC (3), H_1_1_1 (2), LE_1_1_1 (8), TS_1_1_1 (1), TS_1_2_1 (1), P (1), RH_1_1_1 (1), PA_1_1_1 (1), CO2_1_1_1 (3), SWC_1_1_1 (9), NETRAD (1), PPFD_IN (1), SW_IN (1), SW_OUT (9), LW_IN (9), LW_OUT (9), TA_1_1_2 (1), TA_1_1_3 (1), SWC_1_1_3 (9), SWC_1_1_2 (9), RH_1_1_2 (1), LE_1_1_2 (9), PA_1_1_2 (1), FC_1_1_2 (3), CO2_1_1_2 (3), FETCH_FILTER (1), FC_SSITC_TEST (1)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Changed 109 missing values to -9999 from 109 instances of (empty value).",
+                                    "Filename component fixed: optional parameter (bad15) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_bad16.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_bad16.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any invalid Missing-Value Formats?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "Missing values are not indicated with -9999 for these variables (number of timestamps): "
+                                ],
+                                "status_body": [
+                                    "USTAR (11), WD (1)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: USTAR. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Changed 12 missing values to -9999 from 11 instances of -6999 and 1 instance of NaN.",
+                                    "Filename component fixed: optional parameter (bad16) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_bad17.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001010000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_bad17.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamps in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "7",
+                                    "7"
+                                ],
+                                "status_body": [
+                                    " timestamps in TIMESTAMP_START have invalid format (YYYYMMDDHHMM is standard AmeriFlux format).",
+                                    " timestamps in TIMESTAMP_END have invalid format (YYYYMMDDHHMM is standard AmeriFlux format)."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Set 14 timestamps to minute resolution (YYYYMMDDHHMM is standard AmeriFlux FP-In format).",
+                                    "Filename component fixed: optional parameter (bad17) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_bad18.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_bad18.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Timestamp duplicates?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "1",
+                                    "1"
+                                ],
+                                "status_body": [
+                                    " duplicate timestamp found in TIMESTAMP_START",
+                                    " duplicate timestamp found in TIMESTAMP_END"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Is Timestamp resolution OK?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "1",
+                                    "1"
+                                ],
+                                "status_body": [
+                                    "  timestamp in  in TIMESTAMP_START have invalid resolution between within or between rows",
+                                    "  timestamp in  in TIMESTAMP_END have invalid resolution between within or between rows"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING",
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Removed 1 timestamp duplicate.",
+                                    "Filename component fixed: optional parameter (bad18) removed from filename"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            },
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Unable to validate timestamps for 1 lines (including any duplicated timestamps reported above). These lines were removed. Gap-filling may have occurred to fill any resulting missing timestamps. However more than 1% of file data was changed and QA/QC will not be continued.",
+                                    "File had issues that could not be automatically corrected. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 00:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad19.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad19.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Is Timestamp resolution OK?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "2",
+                                    "2"
+                                ],
+                                "status_body": [
+                                    "  timestamps in  in TIMESTAMP_START have invalid resolution between within or between rows",
+                                    "  timestamps in  in TIMESTAMP_END have invalid resolution between within or between rows"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables with ALL Data Missing?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variables have all data missing: "
+                                ],
+                                "status_body": [
+                                    "LE_1_1_2"
+                                ],
+                                "status_suffix": [
+                                    ". Previously uploaded data with the same time period will be overwritten."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filled 2 timestamp gaps with missing data values (-9999).",
+                                    "Filename component fixed: optional parameter (bad19) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad20.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad20.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables with ALL Data Missing?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variables have all data missing: "
+                                ],
+                                "status_body": [
+                                    "LE_1_1_1, SWC_1_1_1, SW_OUT, LW_IN, LW_OUT, SWC_1_1_3, SWC_1_1_2, LE_1_1_2"
+                                ],
+                                "status_suffix": [
+                                    ". Previously uploaded data with the same time period will be overwritten."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: optional parameter (bad20) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_NS.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC_QC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, PREC, RH_F_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_NS.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "SC_QC, PREC"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "NOTE un-fixable variable names: SC_QC; PREC",
+                                    "Filename component fixed: optional parameter (NS) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad21.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad21.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: USTAR, TA_1_1_1. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: optional parameter (bad21) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad22.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad22.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables with ALL Data Missing?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variables have all data missing: "
+                                ],
+                                "status_body": [
+                                    "SWC_1_1_1"
+                                ],
+                                "status_suffix": [
+                                    ". Previously uploaded data with the same time period will be overwritten."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: optional parameter (bad22) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad23.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR5, TA_QC_1_1_1, WinD, WSpeed, FCO2_1_1_1, SC5, Heat_1_1_1, LEvap_1_1_1, TSoil_1_1_1, TSoil_1_2_1, Prep, RelH_1_1_1, PAtom_1_1_1, CO2flux_1_1_1, soilwater_1_1_1, NETRad, PPFD_IN_UI, SW_IN_canopy, SW_OUT_canopy, LW_IN_canopy, LW_OUT_canopy, TAir_1_1_2, TAir_1_1_3, soilwater_1_1_3, soilwater_1_1_2, RelH_1_1_2, LEvap_1_1_2, PAtom_1_1_2, FCO2_1_1_2, CO2flux_1_1_2, FETCH_FILTER_flag, FC_SSITC_TEST_flag",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad23.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "USTAR5, TA_QC_1_1_1, WinD, WSpeed, FCO2_1_1_1, SC5, Heat_1_1_1, LEvap_1_1_1, TSoil_1_1_1, TSoil_1_2_1, Prep, RelH_1_1_1, PAtom_1_1_1, CO2flux_1_1_1, soilwater_1_1_1, NETRad, PPFD_IN_UI, SW_IN_canopy, SW_OUT_canopy, LW_IN_canopy, LW_OUT_canopy, TAir_1_1_2, TAir_1_1_3, soilwater_1_1_3, soilwater_1_1_2, RelH_1_1_2, LEvap_1_1_2, PAtom_1_1_2, FCO2_1_1_2, CO2flux_1_1_2, FETCH_FILTER_flag, FC_SSITC_TEST_flag"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are any standard AmeriFlux Data Variable names present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "No data variables in the standard AmeriFlux format are present."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are primary flux Data Variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "None of the primary flux variables (FC or FCH4, LE, H) are present."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Fixed invalid variable name TSoil_1_1_1 with TS_1_1_1: made uppercase; found synonym",
+                                    "Fixed invalid variable name TSoil_1_2_1 with TS_1_2_1: made uppercase; found synonym",
+                                    "Fixed invalid variable name NETRad with NETRAD: made uppercase",
+                                    "NOTE un-fixable variable names: USTAR5; TA_QC_1_1_1; WinD; WSpeed; FCO2_1_1_1; SC5; Heat_1_1_1; LEvap_1_1_1; Prep; RelH_1_1_1; PAtom_1_1_1; CO2flux_1_1_1; soilwater_1_1_1; PPFD_IN_UI; SW_IN_canopy; SW_OUT_canopy; LW_IN_canopy; LW_OUT_canopy; TAir_1_1_2; TAir_1_1_3; soilwater_1_1_3; soilwater_1_1_2; RelH_1_1_2; LEvap_1_1_2; PAtom_1_1_2; FCO2_1_1_2; CO2flux_1_1_2; FETCH_FILTER_flag; FC_SSITC_TEST_flag",
+                                    "Filename component fixed: optional parameter (bad23) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMx_H_200001011_200001012000_badfilename.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMx_H_200001011_200001012000_badfilename.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING",
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "ts-start (start time), optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            },
+                            "ERROR": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "SITE_ID, resolution"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Do filename time components match file time period?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "TIMESTAMP_START 200001011000 does not match filename ts-start time 200001011"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Is Timestamp resolution OK?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename resolution not valid. Timestamp resolution verification is INCOMPLETE."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename components fixed: SITE_ID; resolution; ts-start (start time); optional parameter (badfilename) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_201703150000_201703151200.pdf": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "Format QA/QC INCOMPLETE. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.pdf"
+                    ],
+                    "headers": "Unable to extract headers from file",
+                    "upload_filename": "US-UMB_HR_201703150000_201703151200.pdf"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "extension is not csv"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Did Format QA/QC complete successfully?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Format QA/QC INCOMPLETE."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "File could not be converted/extracted to csv. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "File Conversion Successful?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Conversion from .pdf to CSV not supported"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.pdf"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR.zip": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-multi_zip_uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "Automated extraction of US.zip was attempted and the included files were re-uploaded. See separate Format QA/QC report for each included file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.zip"
+                    ],
+                    "headers": "Header information not available from archival file type (e.g., zip, 7z).",
+                    "upload_filename": "US-UMB_HR.zip"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is file type a standard AmeriFlux archival format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "Uploaded file "
+                                ],
+                                "status_body": [
+                                    "US.zip"
+                                ],
+                                "status_suffix": [
+                                    " is a standard AmeriFlux archival file type (e.g., zip, 7z). See additional messages for extraction results."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "NOTE: Zip file contains multiple files. Created new upload and retired zip file."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.zip"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_one.zip": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "Automated extraction of US.zip was attempted",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.zip"
+                    ],
+                    "headers": "Header information not available from archival file type (e.g., zip, 7z).",
+                    "upload_filename": "US-UMB_HR_one.zip"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is file type a standard AmeriFlux archival format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "Uploaded file "
+                                ],
+                                "status_body": [
+                                    "US.zip"
+                                ],
+                                "status_suffix": [
+                                    " is a standard AmeriFlux archival file type (e.g., zip, 7z). See additional messages for extraction results."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "NOTE: Single file US-UMB_HR_200001011000_200001012000.csv was extracted from the Zip file.",
+                                    "Filename had incorrect number of components. Fixed filename as described below.",
+                                    "Filename components fixed: SITE_ID; resolution; ts-start (start time); ts-end (end time)",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.zip"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_empty.zip": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "Automated extraction of US.zip was attempted and FAILED.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.zip"
+                    ],
+                    "headers": "Header information not available from archival file type (e.g., zip, 7z).",
+                    "upload_filename": "US-UMB_HR_empty.zip"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is file type a standard AmeriFlux archival format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "Uploaded file "
+                                ],
+                                "status_body": [
+                                    "US.zip"
+                                ],
+                                "status_suffix": [
+                                    " is a standard AmeriFlux archival file type (e.g., zip, 7z). See additional messages for extraction results."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "File could not be converted/extracted to csv. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "File Conversion Successful?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "File with zip extension does not appear to contain any files."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.zip"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad24.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_F_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad24.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: optional parameter (bad24) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad25.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_F_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad25.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are non-filled data present for primary flux, gap-filled Data Variables?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "These primary flux variables are marked gap-filled: "
+                                ],
+                                "status_body": [
+                                    "FC_F_1_1_1"
+                                ],
+                                "status_suffix": [
+                                    ". Corresponding non-filled data could not be identified and must also be submitted."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: optional parameter (bad25) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad26.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1_F, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1_F, TS_F_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_F_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad26.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "TA_1_1_1_F, TS_1_1_1_F"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: TA_1_1_1_F, TS_1_1_1_F. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Fixed invalid variable name TA_1_1_1_F with TA_F_1_1_1: re-ordered qualifiers",
+                                    "Fixed invalid variable name TS_1_1_1_F with TS_F_1_1_1: re-ordered qualifiers",
+                                    "Filename component fixed: optional parameter (bad26) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad27.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, FC_F_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad27.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: optional parameter (bad27) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000.zip": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "Automated extraction of US.zip was attempted and FAILED.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.zip"
+                    ],
+                    "headers": "Header information not available from archival file type (e.g., zip, 7z).",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000.zip"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is file type a standard AmeriFlux archival format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "Uploaded file "
+                                ],
+                                "status_body": [
+                                    "US.zip"
+                                ],
+                                "status_suffix": [
+                                    " is a standard AmeriFlux archival file type (e.g., zip, 7z). See additional messages for extraction results."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "File could not be converted/extracted to csv. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "File Conversion Successful?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "File with zip extension does not appear to be a zip file."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.zip"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad28.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, ONE, TWO, THREE, Four, FIVE, Six, Seven, Eight, Nine, Ten, Eleven, Twelve, Thirteen, Forteen, Fifteen, Sixteen, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, x30, x31, x32",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad28.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "ONE, TWO, THREE, Four, FIVE, Six, Seven, Eight, Nine, Ten, Eleven, Twelve, Thirteen, Forteen, Fifteen, Sixteen, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, x30, x31, x32"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are any standard AmeriFlux Data Variable names present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "No data variables in the standard AmeriFlux format are present."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are primary flux Data Variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "None of the primary flux variables (FC or FCH4, LE, H) are present."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING",
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "NOTE un-fixable variable names: ONE; TWO; THREE; Four; FIVE; Six; Seven; Eight; Nine; Ten; Eleven; Twelve; Thirteen; Forteen; Fifteen; Sixteen; x17; x18; x19; x20; x21; x22; x23; x24; x25; x26; x27; x28; x29; x30; x31; x32"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            },
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "File does not have any valid AmeriFlux data variable names.",
+                                    "File had issues that could not be automatically corrected. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_allgood.zip": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-multi_zip_uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "Automated extraction of US.zip was attempted and the included files were re-uploaded. See separate Format QA/QC report for each included file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.zip"
+                    ],
+                    "headers": "Header information not available from archival file type (e.g., zip, 7z).",
+                    "upload_filename": "US-UMB_HR_allgood.zip"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is file type a standard AmeriFlux archival format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "Uploaded file "
+                                ],
+                                "status_body": [
+                                    "US.zip"
+                                ],
+                                "status_suffix": [
+                                    " is a standard AmeriFlux archival file type (e.g., zip, 7z). See additional messages for extraction results."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "NOTE: Zip file contains multiple files. Created new upload and retired zip file."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.zip"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad29.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, TA_1_1_1_F, H_F_1_1_1, LE_F_PI_1_1_1, TS_1_1_1_PI_F, FC_1_2_1_PI_F, FC_1_1_1, LE_1_1_1, USTAR, WD, WS, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad29.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "TA_1_1_1_F, LE_F_PI_1_1_1, TS_1_1_1_PI_F, FC_1_2_1_PI_F"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: TA_1_1_1_F, LE_F_PI_1_1_1, FC_1_1_1. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are non-filled data present for primary flux, gap-filled Data Variables?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "These primary flux variables are marked gap-filled: "
+                                ],
+                                "status_body": [
+                                    "H_F_1_1_1"
+                                ],
+                                "status_suffix": [
+                                    ". Corresponding non-filled data could not be identified and must also be submitted."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Fixed invalid variable name TA_1_1_1_F with TA_F_1_1_1: re-ordered qualifiers",
+                                    "Fixed invalid variable name LE_F_PI_1_1_1 with LE_F_1_1_1: removed _PI qualifier",
+                                    "Fixed invalid variable name TS_1_1_1_PI_F with TS_F_1_1_1: removed _PI qualifier; re-ordered qualifiers",
+                                    "Fixed invalid variable name FC_1_2_1_PI_F with FC_F_1_2_1: removed _PI qualifier; re-ordered qualifiers",
+                                    "Filename component fixed: optional parameter (bad29) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_scinot.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_scinot.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamps in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "10",
+                                    "10"
+                                ],
+                                "status_body": [
+                                    " timestamps in TIMESTAMP_START have invalid format (YYYYMMDDHHMM is standard AmeriFlux format).",
+                                    " timestamps in TIMESTAMP_END have invalid format (YYYYMMDDHHMM is standard AmeriFlux format)."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Timestamps are in scientific notation and cannot be fixed",
+                                    "Unable to correct timestamps. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001011100_200001011900_NS.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011100_200001011900.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, LE_1_1_1, LE_F_1_1_1, H_1_1_1, TSOIL_1_1_1, FC_1_2_1, FC_1_1_1, LE_1_1_2, USTAR, WD, WS, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_3, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011100_200001011900_NS.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "TSOIL_1_1_1"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: LE_1_1_1, H_1_1_1, TSOIL_1_1_1, FC_1_2_1, FC_1_1_1. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Fixed invalid variable name TSOIL_1_1_1 with TS_1_1_1: found synonym",
+                                    "Filename component fixed: optional parameter (NS) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 11:00",
+            "data_timestamp_end": "2000-01-01 19:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001011900.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001011900.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, LE_1_1_1, LE_F_1_1_1, H_1_1_1, TSOIL_1_1_1, FC_1_2_1, FC_1_1_1, LE_1_1_2, USTAR, WD, WS, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_3, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001011900.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "TSOIL_1_1_1"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: FC_1_1_1. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Fixed invalid variable name TSOIL_1_1_1 with TS_1_1_1: found synonym",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 19:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001011900_NS.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001011900.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR5, TA_QC_1_1_1, WinD, WSpeed, FCO2_1_1_1, SC5, Heat_1_1_1, LEvap_1_1_1, TSoil_1_1_1, TSoil_1_2_1, Prep, RelH_1_1_1, PAtom_1_1_1, CO2flux_1_1_1, soilwater_1_1_1, NETRad, PPFD_IN_UI, SW_IN_canopy, SW_OUT_canopy, LW_IN_canopy, LW_OUT_canopy, TAir_1_1_2, TAir_1_1_3, soilwater_1_1_3, soilwater_1_1_2, RelH_1_1_2, FH2O_1_1_2, PAtom_1_1_2, FCO2_1_1_2, CO2flux_1_1_2, FETCH_FILTER_flag, FC_SSITC_TEST_flag",
+                    "upload_filename": "US-UMB_HR_200001011000_200001011900_NS.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "USTAR5, TA_QC_1_1_1, WinD, WSpeed, FCO2_1_1_1, SC5, Heat_1_1_1, LEvap_1_1_1, TSoil_1_1_1, TSoil_1_2_1, Prep, RelH_1_1_1, PAtom_1_1_1, CO2flux_1_1_1, soilwater_1_1_1, NETRad, PPFD_IN_UI, SW_IN_canopy, SW_OUT_canopy, LW_IN_canopy, LW_OUT_canopy, TAir_1_1_2, TAir_1_1_3, soilwater_1_1_3, soilwater_1_1_2, RelH_1_1_2, PAtom_1_1_2, FCO2_1_1_2, CO2flux_1_1_2, FETCH_FILTER_flag, FC_SSITC_TEST_flag"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are primary flux Data Variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "None of the primary flux variables (FC or FCH4, LE, H) are present."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Fixed invalid variable name TSoil_1_1_1 with TS_1_1_1: made uppercase; found synonym",
+                                    "Fixed invalid variable name TSoil_1_2_1 with TS_1_2_1: made uppercase; found synonym",
+                                    "Fixed invalid variable name NETRad with NETRAD: made uppercase",
+                                    "NOTE un-fixable variable names: USTAR5; TA_QC_1_1_1; WinD; WSpeed; FCO2_1_1_1; SC5; Heat_1_1_1; LEvap_1_1_1; Prep; RelH_1_1_1; PAtom_1_1_1; CO2flux_1_1_1; soilwater_1_1_1; PPFD_IN_UI; SW_IN_canopy; SW_OUT_canopy; LW_IN_canopy; LW_OUT_canopy; TAir_1_1_2; TAir_1_1_3; soilwater_1_1_3; soilwater_1_1_2; RelH_1_1_2; PAtom_1_1_2; FCO2_1_1_2; CO2flux_1_1_2; FETCH_FILTER_flag; FC_SSITC_TEST_flag",
+                                    "Filename component fixed: optional parameter (NS) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 19:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001011800_NS.csv": {
+        "run_type": "r",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Additional input is needed to further process the data.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, ONE, TWO, THREE, Four, FIVE, Six, Seven, Eight, Nine, Ten, Eleven, Twelve, Thirteen, Forteen, Fifteen, Sixteen, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, x30, x31, x32",
+                    "upload_filename": "US-UMB_HR_200001011000_200001011800_NS.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "ONE, TWO, THREE, Four, FIVE, Six, Seven, Eight, Nine, Ten, Eleven, Twelve, Thirteen, Forteen, Fifteen, Sixteen, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, x30, x31, x32"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are any standard AmeriFlux Data Variable names present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "No data variables in the standard AmeriFlux format are present."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are primary flux Data Variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "None of the primary flux variables (FC or FCH4, LE, H) are present."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "Autocorrected file: US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 18:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_Inf.csv": {
+        "run_type": "r",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Additional input is needed to further process the data.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_Inf.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any invalid Missing-Value Formats?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "Missing values are not indicated with -9999 for these variables (number of timestamps): "
+                                ],
+                                "status_body": [
+                                    "WS (4)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "Autocorrected file: US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_bad30.csv": {
+        "run_type": "r",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Additional input is needed to further process the data.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, VPD_PI, NEE_PI, FC_PI, SC_PI_F, F_1_1_1, LE_1_1_2_f, TS_1_1_1_pi_f, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_bad30.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "VPD_PI, NEE_PI, FC_PI, SC_PI_F, F_1_1_1, LE_1_1_2_f, TS_1_1_1_pi_f"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Do filename time components match file time period?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "TIMESTAMP_START 200001011000 does not match filename ts-start time 200001010000"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Is Timestamp resolution OK?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "2",
+                                    "1"
+                                ],
+                                "status_body": [
+                                    "  timestamps in  in TIMESTAMP_START have invalid resolution between within or between rows",
+                                    "  timestamp in  have invalid resolution within within or between rows"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "Autocorrected file: US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad31.csv": {
+        "run_type": "r",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "Problem while loading data file; QA/QC INCOMPLETE. Additional input is needed to further process the data.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad31.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any problems reading file?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Error reading data from the file. ."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "Autocorrected file: US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HH_200001011000_200001012000.csv": {
+        "run_type": "r",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Additional input is needed to further process the data.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "YEAR, MONTH, DAY, HOUR, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HH_200001011000_200001012000.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Are Timestamp variables as expected?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    " These unexpected variables were found in columns 1 & 2 instead of TIMESTAMP_START and TIMESTAMP_END: "
+                                ],
+                                "status_body": [
+                                    "YEAR, MONTH"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "YEAR, MONTH, DAY, HOUR"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [
+                                    "Expected timestamp variable(s) "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP_START, TIMESTAMP_END"
+                                ],
+                                "status_suffix": [
+                                    " is / are missing."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: YEAR, MONTH, DAY, HOUR. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "Autocorrected file: US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad32.csv": {
+        "run_type": "r",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Additional input is needed to further process the data.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "YEAR, MONTH, DAY, HOUR, MIN, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad32.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables as expected?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    " These unexpected variables were found in columns 1 & 2 instead of TIMESTAMP_START and TIMESTAMP_END: "
+                                ],
+                                "status_body": [
+                                    "YEAR, MONTH"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "YEAR, MONTH, DAY, HOUR, MIN"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [
+                                    "Expected timestamp variable(s) "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP_START, TIMESTAMP_END"
+                                ],
+                                "status_suffix": [
+                                    " is / are missing."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: YEAR, MONTH, DAY, HOUR, MIN. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "Autocorrected file: US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad33.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "Year, Month, Day, Hour, Min, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad33.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables as expected?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    " These unexpected variables were found in columns 1 & 2 instead of TIMESTAMP_START and TIMESTAMP_END: "
+                                ],
+                                "status_body": [
+                                    "Year, Month"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "Year, Month, Day, Hour, Min"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [
+                                    "Expected timestamp variable(s) "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP_START, TIMESTAMP_END"
+                                ],
+                                "status_suffix": [
+                                    " is / are missing."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: Year, Month, Day, Hour, Min. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "NOTE un-fixable variable names: Year; Month; Day; Hour; Min",
+                                    "Generated timestamp variables TIMESTAMP_START and TIMESTAMP_END from YEAR MONTH DAY HOUR MIN variables assuming data was reporting at the beginning of the half hour. This automated fix is only available temporarily.",
+                                    "Filename component fixed: optional parameter (bad33) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_bad34.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA _1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_bad34.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    " TIMESTAMP_END, USTAR , TA _1_1_1"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Fixed invalid variable name  TIMESTAMP_END with TIMESTAMP_END: whitespace removed",
+                                    "Fixed invalid variable name USTAR  with USTAR: whitespace removed",
+                                    "Fixed invalid variable name TA _1_1_1 with TA_1_1_1: whitespace removed",
+                                    "Filename component fixed: optional parameter (bad34) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001011500.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001011600.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001011500.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Are quotes found in all variable names?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "All variable names have quotes."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Do filename time components match file time period?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "TIMESTAMP_END 200001011600 does not match filename ts-end time 200001011500"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Quotes around variable names removed.",
+                                    "Filename component fixed: ts-end (end time)",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 16:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001011400.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001011400.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001011400.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "\"TIMESTAMP_START\", \"TIMESTAMP_END\""
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: TA_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, NETRAD, PPFD_IN, SW_IN, TA_1_1_2, TA_1_1_3, RH_1_1_2, PA_1_1_2, FETCH_FILTER, FC_SSITC_TEST. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables with ALL Data Missing?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variables have all data missing: "
+                                ],
+                                "status_body": [
+                                    "SWC_1_1_1, SW_OUT, LW_IN, LW_OUT, SWC_1_1_3, SWC_1_1_2"
+                                ],
+                                "status_suffix": [
+                                    ". Previously uploaded data with the same time period will be overwritten."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Fixed invalid variable name \"TIMESTAMP_START\" with TIMESTAMP_START: quotes removed",
+                                    "Fixed invalid variable name \"TIMESTAMP_END\" with TIMESTAMP_END: quotes removed",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 14:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001011300.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001011300.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001011300.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "\"TA_1_1_1\""
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: TA_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, NETRAD, PPFD_IN, SW_IN, TA_1_1_2, TA_1_1_3, RH_1_1_2, PA_1_1_2, FETCH_FILTER, FC_SSITC_TEST. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables with ALL Data Missing?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variables have all data missing: "
+                                ],
+                                "status_body": [
+                                    "LE_1_1_1, SWC_1_1_1, SW_OUT, LW_IN, LW_OUT, SWC_1_1_3, SWC_1_1_2, LE_1_1_2"
+                                ],
+                                "status_suffix": [
+                                    ". Previously uploaded data with the same time period will be overwritten."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Fixed invalid variable name \"TA_1_1_1\" with TA_1_1_1: quotes removed",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 13:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001011200.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001011200.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE\"_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001011200.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "LE\"_1_1_1"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: TA_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, NETRAD, PPFD_IN, SW_IN, TA_1_1_2, TA_1_1_3, RH_1_1_2, PA_1_1_2, FETCH_FILTER, FC_SSITC_TEST. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables with ALL Data Missing?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variables have all data missing: "
+                                ],
+                                "status_body": [
+                                    "FC_1_1_1, SC, LE_1_1_1, CO2_1_1_1, SWC_1_1_1, SW_OUT, LW_IN, LW_OUT, SWC_1_1_3, SWC_1_1_2, LE_1_1_2, FC_1_1_2, CO2_1_1_2"
+                                ],
+                                "status_suffix": [
+                                    ". Previously uploaded data with the same time period will be overwritten."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Fixed invalid variable name LE\"_1_1_1 with LE_1_1_1: quotes removed",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 12:00"
+        }
+    },
+    "US-UMB_HR_200001011200_200001012000.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. No issues were encountered. Data will be queued for further data processing.",
+                    "status_code": "OK"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011200_200001012000.csv"
+                },
+                "check_summary": {},
+                "checks": [],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 12:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011300_200001012000.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011300_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011300_200001012000.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Are Timestamps in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "1",
+                                    "1"
+                                ],
+                                "status_body": [
+                                    " timestamp in TIMESTAMP_START have invalid format (YYYYMMDDHHMM is standard AmeriFlux format).",
+                                    " timestamp in TIMESTAMP_END have invalid format (YYYYMMDDHHMM is standard AmeriFlux format)."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Quotes around data values in 1 line(s) were removed.",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001011400_200001012000.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011400_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011400_200001012000.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Are Timestamps in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "2",
+                                    "2"
+                                ],
+                                "status_body": [
+                                    " timestamps in TIMESTAMP_START have invalid format (YYYYMMDDHHMM is standard AmeriFlux format).",
+                                    " timestamps in TIMESTAMP_END have invalid format (YYYYMMDDHHMM is standard AmeriFlux format)."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    1,
+                                    1
+                                ],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Quotes around data values in 2 line(s) were removed.",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_210001011000_210001012000_bad35.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_210001011000_210001012000_bad35.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamps filled into the future?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Last timestamp in file 210001011900 is in the future. Forward-filled timestamps are not accepted."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Timestamps are filled into future. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2100-01-01 10:00",
+            "data_timestamp_end": "2100-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "ERROR"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "filename ends with underscore"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: trailing underscore removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HR_200001011000_200001012000_FCH4.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": true,
+            "upload_uuid": "test-autorepair-uuid",
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and autocorrected file was uploaded: US-UMB_HR_200001011000_200001012000.csv. See Format QA/QC report for autocorrected file.",
+                    "status_code": "WARNING"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FCH4_1_1_1, SC, TS_2_1_1, TS_3_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001011000_200001012000_FCH4.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Filename component fixed: optional parameter (FCH4) removed from filename",
+                                    "File was Autocorrected and corrected file uploaded."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": "2000-01-01 10:00",
+            "data_timestamp_end": "2000-01-01 20:00"
+        }
+    },
+    "US-UMB_HH_209001011000_209001012000.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "YEAR, MONTH, DAY, HOUR, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC, H_1_1_1, LE_1_1_1, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HH_209001011000_209001012000.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Are Timestamp variables as expected?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [
+                                    " These unexpected variables were found in columns 1 & 2 instead of TIMESTAMP_START and TIMESTAMP_END: "
+                                ],
+                                "status_body": [
+                                    "YEAR, MONTH"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "YEAR, MONTH, DAY, HOUR"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamp variables present?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [
+                                    "Expected timestamp variable(s) "
+                                ],
+                                "status_body": [
+                                    "TIMESTAMP_START, TIMESTAMP_END"
+                                ],
+                                "status_suffix": [
+                                    " is / are missing."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any Variables suspected gap-fill?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These variables are suspected to be gap-filled because they have no missing values: YEAR, MONTH, DAY, HOUR. If these variables are gap-filled, use the _F variable qualifier. Non-filled data must be submitted for primary flux variables (FC, FCH4, LE, H). Consider submitting non-filled data for all other variables."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING",
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "NOTE un-fixable variable names: YEAR; MONTH; DAY; HOUR",
+                                    "Generated timestamp variables TIMESTAMP_START and TIMESTAMP_END from YEAR MONTH DAY HOUR MIN variables assuming data was reporting at the beginning of the half hour. This automated fix is only available temporarily."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            },
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Timestamps are filled into future. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    },
+    "US-UMB_HR_200001010000_200001012000_bad36.csv": {
+        "run_type": "o",
+        "output": {
+            "is_upload_successful": null,
+            "upload_uuid": null,
+            "report": {
+                "process_type": "File Format",
+                "process_log_file": "QAQC_report_US-UMB_999999_20240325090000.log",
+                "processor": "unittester",
+                "process_datetime": "2024-Mar-25 09:00 ",
+                "process_confirmation": {
+                    "status_start_msg": null,
+                    "status_end_msg": "All format QA/QC checks attempted. Autocorrection of detected issues was attempted and FAILED.",
+                    "status_code": "CRITICAL"
+                },
+                "files": {
+                    "new": [
+                        "US.csv"
+                    ],
+                    "headers": "TIMESTAMP_START, TIMESTAMP_END, USTAR, TA_1_1_1, WD, WS, FC_1_1_1, SC_QC, H_1_1_1, LE_1_1_2, TS_1_1_1, TS_1_2_1, P, RH_1_1_1, PA_1_1_1, CO2_1_1_1, SWC_1_1_1, NETRAD, PPFD_IN, SW_IN, SW_OUT, LW_IN, LW_OUT, TA_1_1_2, TA_1_1_3, SWC_1_1_3, SWC_1_1_2, RH_1_1_2, LE_1_1_2, PA_1_1_2, FC_1_1_2, CO2_1_1_2, FETCH_FILTER, FC_SSITC_TEST",
+                    "upload_filename": "US-UMB_HR_200001010000_200001012000_bad36.csv"
+                },
+                "check_summary": {},
+                "checks": [
+                    {
+                        "check_name": "Is Filename Format valid?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These filename components are not in the standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "optional parameter included (will be removed in autocorrected file)"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Any duplicate Variable names?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "1 additional instance of LE_1_1_2 temporarily renamed to LE_1_1_2_d1. ",
+                                    ""
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Data Variable names in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [
+                                    "These variable names are not in standard AmeriFlux format: "
+                                ],
+                                "status_body": [
+                                    "SC_QC"
+                                ],
+                                "status_suffix": [
+                                    ". They will not be included in the standard AmeriFlux data products. Non-standard variables will be saved for a non-standard data product that will be available in future."
+                                ],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    1
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Are Timestamps in correct format?",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    " Unexpected critical error. Timestamp format verification is INCOMPLETE."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "Incomplete Timestamp Checks",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "CRITICAL"
+                        ],
+                        "status_msg": {
+                            "CRITICAL": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "These Format QA/QC assessments could not be completed: Do filename time components match file time period? Is Timestamp resolution OK? Any Timestamp duplicates?"
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [
+                                    0
+                                ],
+                                "emphasize_body": [
+                                    0
+                                ],
+                                "emphasize_suffix": [
+                                    0
+                                ],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    },
+                    {
+                        "check_name": "AutoRepair Fixes and/or Error Messages",
+                        "general_code": null,
+                        "general_msg": null,
+                        "status_code": [
+                            "WARNING",
+                            "ERROR"
+                        ],
+                        "status_msg": {
+                            "WARNING": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "NOTE un-fixable variable name: SC_QC",
+                                    "Filled 1 timestamp gap with missing data values (-9999)."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            },
+                            "ERROR": {
+                                "status_prefix": [],
+                                "status_body": [
+                                    "Unable to validate timestamps for 2 lines (including any duplicated timestamps reported above). These lines were removed. Gap-filling may have occurred to fill any resulting missing timestamps. However more than 1% of file data was changed and QA/QC will not be continued.",
+                                    "File has duplicate variables LE_1_1_2 (column 29).",
+                                    "File had issues that could not be automatically corrected. Autocorrection FAILED."
+                                ],
+                                "status_suffix": [],
+                                "emphasize_prefix": [],
+                                "emphasize_body": [
+                                    0,
+                                    0,
+                                    0
+                                ],
+                                "emphasize_suffix": [],
+                                "one_plot": null,
+                                "all_plots": [],
+                                "targeted_plots": [],
+                                "plot_dir_path": null
+                            }
+                        },
+                        "sub_status": []
+                    }
+                ],
+                "report_title": "US.csv"
+            },
+            "data_timestamp_start": null,
+            "data_timestamp_end": null
+        }
+    }
+}

--- a/processing/upload_checks.py
+++ b/processing/upload_checks.py
@@ -67,6 +67,7 @@ def upload_checks(
             return None, False, None
     else:
         process_id = 999999
+        start_time = dt.strptime('2024-03-25 09:00', '%Y-%m-%d %H:%M')
 
     _log = Logger(True, process_id, site_id, process_type,
                   start_time).getLogger('upload_checks')  # Initialize logger
@@ -206,7 +207,6 @@ def upload_checks(
 
         # this code decides whether to go to fixer or not!
         process_status_code = min([s.get_status_code() for s in statuses])
-        print(process_status_code)
 
         if process_status_code > -1:
             status_msg += (' No issues were encountered. Data will be'

--- a/processing/upload_checks.py
+++ b/processing/upload_checks.py
@@ -23,7 +23,7 @@ from file_fixer import FileFixer
 from shutil import copyfile
 from missing_value_format import MissingValueFormat
 from data_missing import DataMissing
-from utils import FilenameUtils
+from utils import FilenameUtils, TimestampUtil
 from data_report_gen import gen_description
 from messages import Messages
 
@@ -67,7 +67,7 @@ def upload_checks(
             return None, False, None
     else:
         process_id = 999999
-        start_time = dt.strptime('2024-03-25 09:00', '%Y-%m-%d %H:%M')
+        start_time = dt.strptime('202403250900', TimestampUtil().PREFERRED_TS_FORMAT)
 
     _log = Logger(True, process_id, site_id, process_type,
                   start_time).getLogger('upload_checks')  # Initialize logger


### PR DESCRIPTION
This PR adds automated testing of the previous manual tests.

In the process, discovered that some loggers needed to be reset for cases when the upload_checks method is called within a python script (as it will in the new driver).

Note: the numpy.genfromtxt issue is not resolved. I'm confident it is a weird purest issue. I will write a separate test later for the case of an empty file.

- [x] I have reviewed my code to check that it contains no sensitive information.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests or modified existing tests that prove my fix is effective or that my feature works
- [x] Existing unit tests pass locally with my changes

