### PR TITLE
Fix invalid parameter name for matplotlib plot in timestamp_alignment

### DIFF
--- a/processing/timestamp_alignment.py
+++ b/processing/timestamp_alignment.py
@@ -435,7 +435,7 @@ class TimestampAlignment(object):
                     if rem_sw_in_data is not None:
                         leg_pot, = ax.plot(
                             ts_doy_center, rem_sw_in_data[ptr:ptr+step],
-                            fmt='.', lw=1.0, ls='-', markersize=3,
+                            marker='.', lw=1.0, ls='-', markersize=3,
                             color=timestamp_palette[1], markeredgecolor=timestamp_palette[1],
                             alpha=1.0, label=sw_in_pot_label)
                     continue


### PR DESCRIPTION
Closes #131

## PR Self Evaluation

- [x] I have reviewed my code to check that it contains no sensitive information.
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] My changes generate no new warnings
~- [ ] I have added tests or modified existing tests that prove my fix is effective or that my feature works~
- [x] Existing unit tests pass locally with my changes

Also tested fully on dev system.
