### PR TITLE
DRAFT: Handle missing reporter information in data qaqc ticket generation

### DIFF
--- a/processing/data_report_gen.py
+++ b/processing/data_report_gen.py
@@ -9,7 +9,7 @@ from datetime import datetime as dt
 from jira_interface import JIRAInterface
 from jira_names import JIRANames
 from logger import Logger
-from report_status import ReportStatus
+from report_status import ReportStatus, ReportStatusException
 from site_attrs import SiteAttributes
 
 __author__ = 'Norm Beekwilder, Danielle Christianson'
@@ -112,6 +112,46 @@ class DataReportGen:
                 self_review_sites.append(site_id)
         return self_review_sites
 
+    def _get_site_team_members(self, site_id: str) -> dict:
+        """
+        Get dictionary of site team members from the webservices
+
+        :param site_id: site identifier
+        """
+        try:
+            return ReportStatus().get_site_users(site_id)
+
+        except ReportStatusException as e:
+            _log.warning(f'Invalid return for site team users endnpoint: {e}.')
+            return {}
+
+    def validate_reporter_info(self, data_qaqc_info, site_id):
+        """
+        Check for reporter_id value. If none exists, use reporter_name to
+        find corresponding email address. Set reporter_id to that email
+        address so that Jira can use it to populate the ticket reporter.
+
+        This happens when the site's Site General Info team member email
+        address does not match the user's AmeriFlux account email address.
+        """
+
+        if data_qaqc_info.get('reporter_id'):
+            return
+
+        site_team_members = self._get_site_team_members(site_id)
+        pi_name = data_qaqc_info['reporter_name']
+
+        members_without_amf_accounts = site_team_members.get('other_users', {})
+        pi_email = members_without_amf_accounts.get(pi_name, '')
+
+        data_qaqc_info['reporter_id'] = pi_email
+
+        if not pi_email:
+            _log.warning(f'Could not find email address for {pi_name}. '
+                         f'Data QA/QC ticket will have anonymous reporter')
+
+        return
+
     def gen_report(self, site_id, time_res, process_id, input_file_order,
                    status_list, ftp_link, force_amp_review=False):
         previous_key = self.jira.get_prior_data_qaqc_key(site_id)
@@ -124,15 +164,19 @@ class DataReportGen:
         data_qaqc_info = ReportStatus().get_base_info(
             site_id,
             {'process_ids': format_process_ids})
+
+        if not self.test:
+            self.validate_reporter_info(data_qaqc_info, site_id)
+
         try:
-            # truncate the the last_upload_timestamp
+            # truncate the last_upload_timestamp
             #   and deal with one ts format
             last_upload_ts = dt.strftime(dt.strptime(
                 data_qaqc_info['last_upload_timestamp'][:21],
                 "%Y-%m-%dT%H:%M:%S.%f"), "%b %d, %Y")
         except Exception:
             try:
-                # truncate the the last_upload_timestamp
+                # truncate the last_upload_timestamp
                 #   and deal with the other ts format
                 last_upload_ts = dt.strftime(dt.strptime(
                     data_qaqc_info['last_upload_timestamp'][:21],

--- a/processing/report_status.py
+++ b/processing/report_status.py
@@ -15,6 +15,10 @@ __email__ = 'norm.beekwilder@gmail.com, sytoanngo@lbl.gov'
 _log = Logger().getLogger(__name__)
 
 
+class ReportStatusException(Exception):
+    pass
+
+
 class ReportStatus:
     """upload status report to web server"""
 


### PR DESCRIPTION
Closes #134

## PR Self Evaluation

- [x] I have reviewed my code to check that it contains no sensitive information.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests or modified existing tests that prove my fix is effective or that my feature works
- [x] Existing unit tests pass locally with my changes

