### PR TITLE
Data QA/QC Auto Run: improve logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # AMF-BASE-QAQC Change Log
 
+### QAQC v2.3.2
+*2025 Oct 06*
+
+New in this release:
+- Improve logging for automated evaluation and initiation of Data QA/QC processing.
+
 ### QAQC v2.3.1
 *2025 Sept 29*
 

--- a/processing/qaqc_template.cfg
+++ b/processing/qaqc_template.cfg
@@ -1,5 +1,5 @@
 [VERSION]
-code_version = 2.3.1
+code_version = 2.3.2
 code_major_version = 5
 test = True
 
@@ -59,6 +59,7 @@ data_dir =
 combined_file_dir =
 intermediate_dirname = intermediate
 auto_log_dir = logs
+process_type = 'BASE Generation'
 
 [PHASE_III]
 output_dir = BASE-BADM

--- a/processing/test/test_data_qaqc_auto_run.py
+++ b/processing/test/test_data_qaqc_auto_run.py
@@ -112,9 +112,7 @@ def test_extract_full_record_dates():
       [2010, 2011, 2012, 2013, 2014, 2015, 2016]),
      ({'TEST-A': {'customfield_10800': '2018,2019,2021',
                   'status': {'name': 'Discovered'}},
-       'TEST-B': {'customfield_10800': 'All',
-                  'status': {'name': JIRANames.data_sub_issue_not_issue}},
-       'TEST-C': {'customfield_10800': '2016',
+       'TEST-B': {'customfield_10800': '2016',
                   'status': {'name': 'Discovered'}}},
       [2018, 2019, 2021, 2016])
      ],
@@ -122,20 +120,15 @@ def test_extract_full_record_dates():
 def test_get_years_from_sub_issues(
         subissues, expected_result, monkeypatch, handler):
 
-    def mock_get_jira_issues(dummyself, dummykeys):
-        return subissues
-
     def mock_adjust_date_year(
             dummystatic, dummystartdate, dummyenddate):
         return 2010, 2016
 
     monkeypatch.setattr(DataQAQCAutoRunHandler,
-                        'get_jira_issues', mock_get_jira_issues)
-    monkeypatch.setattr(DataQAQCAutoRunHandler,
                         'adjust_date_year', mock_adjust_date_year)
 
     result = handler.get_years_from_sub_issues(
-        ['TEST'],
+        subissues,
         (dt.fromisoformat('2010-01-01T00:00:00.000'),
          dt.fromisoformat('2016-12-31T23:30:00.000')),)
 


### PR DESCRIPTION
Added more advance log file handler functionality so that the log messages end up in the correct place.
Add a bit more info logging.
Correct handling of case where unresolved prior data qaqc has no unresolved sub-issues.

Note: The current approach has the data QAQC run logs in both the site x process_id-specific log and the data_qaqc_auto log. We might want to change this.

Issue #65

## PR Self Evaluation

- [x] I have reviewed my code to check that it contains no sensitive information.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
~- [ ] I have added tests or modified existing tests that prove my fix is effective or that my feature works~
- [x] Existing unit tests pass locally with my changes

