### PR TITLE
Embargo site check modification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1.1-dependencies-{{ checksum "requirements.txt" }}
+          - v1.2-dependencies-{{ checksum "requirements.txt" }}
           # Use latest cache if no exact match found
-          - v1-dependencies-
+          - v1.2-dependencies-
       - run:
           name: Setup Python Environment
           command: |
@@ -48,7 +48,7 @@ jobs:
       - save_cache:
           paths:
              - ./venv
-          key: v1.1-dependencies-{{ checksum "requirements.txt" }}
+          key: v1.2-dependencies-{{ checksum "requirements.txt" }}
       - run:
           name: Run Pytests
           command: |

--- a/processing/base_creator.py
+++ b/processing/base_creator.py
@@ -319,8 +319,11 @@ class BASECreator():
         psql_conn = self.db_conn_pool.get('psql_conn')
         ext_conn = self.db_conn_pool.get('ext_conn')
         self.site_list = self.new_db_handler.get_published_base_site_attrs(ext_conn)
-        self.embargoed_site_list = self.new_db_handler.get_sites_with_embargo(
-            psql_conn, self.embargo_years)
+        embargoed_site_list = self.new_db_handler.get_sites_with_embargo(
+            psql_conn)
+        self.active_embargoed_sites = \
+            self.new_db_handler.get_sites_still_under_embargo(
+                ext_conn, embargoed_site_list, embargo_years)
         self.historic_site_list = self.new_db_handler.get_sites_with_updates(
             psql_conn, is_historic=True)
         self.preBASE_files = self.new_db_handler.get_base_candidates(
@@ -341,7 +344,9 @@ class BASECreator():
             site_id = file_attrs[0]
             cur_file_res = file_attrs[-1]
             site_id_attrs = base_attrs.get(site_id)
-            if site_id in self.embargoed_site_list:
+            if site_id in self.active_embargoed_sites:
+                info_msg = f'Site {site_id} still under embargo'
+                _log.info(info_msg)
                 continue
 
             if site_id_attrs:

--- a/processing/db_handler.py
+++ b/processing/db_handler.py
@@ -271,17 +271,37 @@ class NewDBHandler:
                 lookup[flux_id] = (hh_version, hr_version)
         return lookup
 
-    def get_sites_with_embargo(self, conn, embargo_years):
+    def get_sites_with_embargo(self, conn):
         site_ids = []
 
-        query = SQL('SELECT flux_id from site_embargo_log '
-                    'WHERE retire_timestamp IS NULL '
-                    'AND EXTRACT(YEARS FROM AGE('
-                    'NOW(), request_timestamp)) < %s')
+        query = SQL('SELECT flux_id FROM site_embargo_log '
+                    'WHERE retire_timestamp IS NULL')
         with conn.cursor(cursor_factory=RealDictCursor) as cursor:
-            cursor.execute(query, (embargo_years,))
+            cursor.execute(query)
             for r in cursor:
                 site_ids.append(r.get('flux_id'))
+        return site_ids
+
+    def get_sites_still_under_embargo(self, conn, embargo_site_ids, embargo_years):
+        site_ids = []
+        query = ('SELECT site_id, '
+                 'EXTRACT (YEARS FROM AGE (NOW(), '
+                 'MIN(process_timestamp))) '
+                 'FROM qaqc.processing_log q '
+                 'INNER JOIN qaqc.state_log s '
+                 'ON s.process_id = q.log_id '
+                 'INNER JOIN qaqc.state_cv_type cv '
+                 'ON cv.type_id = s.state_id '
+                 'AND shortname = %(passed_qaqc_state)s '
+                 'GROUP BY site_id HAVING site_id IN %(embargo_site_ids)s')
+        query = SQL('SELECT flux_id from site_embargo_log '
+                    'WHERE retire_timestamp IS NULL')
+        args = {'passed_qaqc_state': 'Passed by Curator',
+                'embargo_site_ids': embargo_site_ids}
+        with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+            cursor.execute(query, args)
+            for r in cursor:
+                site_ids.append(r.get('site_id'))
         return site_ids
 
     def get_filename_checksum_lookup(self, conn):

--- a/processing/db_handler.py
+++ b/processing/db_handler.py
@@ -294,8 +294,6 @@ class NewDBHandler:
                  'ON cv.type_id = s.state_id '
                  'AND shortname = %(passed_qaqc_state)s '
                  'GROUP BY site_id HAVING site_id IN %(embargo_site_ids)s')
-        query = SQL('SELECT flux_id from site_embargo_log '
-                    'WHERE retire_timestamp IS NULL')
         args = {'passed_qaqc_state': 'Passed by Curator',
                 'embargo_site_ids': embargo_site_ids}
         with conn.cursor(cursor_factory=RealDictCursor) as cursor:

--- a/processing/db_handler.py
+++ b/processing/db_handler.py
@@ -284,16 +284,16 @@ class NewDBHandler:
 
     def get_sites_still_under_embargo(self, conn, embargo_site_ids, embargo_years):
         site_ids = []
-        query = ('SELECT site_id, '
-                 'EXTRACT (YEARS FROM AGE (NOW(), '
-                 'MIN(process_timestamp))) '
-                 'FROM qaqc.processing_log q '
-                 'INNER JOIN qaqc.state_log s '
-                 'ON s.process_id = q.log_id '
-                 'INNER JOIN qaqc.state_cv_type cv '
-                 'ON cv.type_id = s.state_id '
-                 'AND shortname = %(passed_qaqc_state)s '
-                 'GROUP BY site_id HAVING site_id IN %(embargo_site_ids)s')
+        query = SQL('SELECT site_id, '
+                    'EXTRACT (YEARS FROM AGE (NOW(), '
+                    'MIN(process_timestamp))) '
+                    'FROM qaqc.processing_log q '
+                    'INNER JOIN qaqc.state_log s '
+                    'ON s.process_id = q.log_id '
+                    'INNER JOIN qaqc.state_cv_type cv '
+                    'ON cv.type_id = s.state_id '
+                    'AND shortname = %(passed_qaqc_state)s '
+                    'GROUP BY site_id HAVING site_id IN %(embargo_site_ids)s')
         args = {'passed_qaqc_state': 'Passed by Curator',
                 'embargo_site_ids': embargo_site_ids}
         with conn.cursor(cursor_factory=RealDictCursor) as cursor:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ matplotlib==3.9.0
 numpy
 pandas
 psycopg2-binary
-pyparsing==3.0.9
+pyparsing<3.3.0
 pytest
 pytest-cov
 pytest-flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,10 @@ matplotlib==3.9.0
 numpy
 pandas
 psycopg2-binary
+pyparsing==3.0.9
 pytest
 pytest-cov
 pytest-flake8
 requests
 scipy
 xlrd
-


### PR DESCRIPTION
Please include a summary of the change and which issue is addressed.

- Modify checks for embargo, duration of two years should be embargoed from last passed QA/QC timestamp, and not the request timestamp.
- Also add version restriction for pyparsing until we can upgrade to matplotlib 3.11

Fixes / Closes / Implements / Issue #(issue) 

## PR Self Evaluation

- [x] I have reviewed my code to check that it contains no sensitive information.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests or modified existing tests that prove my fix is effective or that my feature works
- [x] Existing unit tests pass locally with my changes

